### PR TITLE
docs(agents): document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,19 @@ Work style: Be radically precise. No fluff. Pure information only (drop grammar;
 - In `plugin.json`, set `brandColor` to the provider's real brand color.
 - Plugin SVG logos must use `currentColor` so icon theming works correctly.
 
+## Cursor Cloud specific instructions
+Env pre-provisioned by update script (`bun install` + `cargo fetch`). Toolchain: Bun (`~/.bun/bin`, add to PATH), Rust stable (default; edition 2024 crates need >=1.85), Tauri Linux libs (webkit2gtk-4.1, gtk3, ayatana-appindicator, libsoup-3, dbus). Virtual display at `DISPLAY=:1`.
+
+Services (single desktop product; no backend server): Vite dev UI (port 1420, auto-started by `beforeDevCommand`), Tauri app (embeds Rust core + local HTTP API on 127.0.0.1:6736). CLI `crossusage-cli` shares the same engine.
+
+- **Standard commands** live in `package.json`/README "Develop": `bun run tauri:dev` (GUI), `bun run test` (Vitest), `bun run build` (typecheck+vite), `cargo test -p crossusage-cli`, `cargo run -p crossusage-cli -- list`.
+- **GUI dev requires the CLI sidecar first** (non-obvious): `bun run tauri:dev` fails with `resource path binaries/crossusage-cli-<triple> doesn't exist` until you run `bash scripts/prepare-cli-sidecar.sh` once (builds `crossusage-cli --release` into `src-tauri/binaries/`). Only `tauri:build` builds it automatically.
+- On Linux the app auto-shows its main window on launch (`panel::show_panel` in `lib.rs` setup); no system tray needed to see the UI under Xvfb.
+- Run the GUI under `DISPLAY=:1`; keep it in a tmux session (`bun run tauri:dev`) — it is long-running.
+- No credentials → real providers probe as "not logged in" (expected). For a GUI usage demo without secrets, enable the built-in `mock` provider by removing `"mock"` from the `disabled` array in `~/.local/share/com.barramee27.crossusage/settings.json`, then restart (settings load only at startup — no hot-reload).
+- Keyring is unavailable (no `secret-tool`/Secret Service); keychain reads log warnings and fail gracefully — harmless.
+- Known env-limited test failures (NOT in CI, do not "fix" in product code): `crossusage-core` tests `ccusage_runner_retries_legacy_package_when_current_package_fails` and `ccusage_timeout_kills_descendant_and_closes_pipes` fail in this sandboxed microVM (subprocess `process_group(0)` timeout/kill behavior). CI only runs `bun run test` + `cargo test -p crossusage-cli`, both of which pass.
+
 ## User Notes
 Use below list to store and recall user notes when asked to do so.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Sets up the development environment for CrossUsage (Tauri v2 desktop app: React/TS frontend + Rust workspace + `crossusage-cli`) and documents non-obvious startup caveats for future Cursor Cloud agents. The only committed change is an `AGENTS.md` addition; the environment itself is refreshed via the update script (`bun install` + `cargo fetch`).

Installed/prepared during setup: Bun, Rust stable 1.96.1 (edition-2024 crates require ≥1.85; base VM shipped 1.83), Tauri Linux libs (webkit2gtk-4.1, gtk3, ayatana-appindicator, libsoup-3, dbus), JS deps, bundled provider plugins, and the CLI sidecar.

## Type of Change

- [x] Documentation

## Testing

- [x] I ran `bun run build` and it succeeded (tsc + vite)
- [x] I ran `bun run test` and all tests pass (95 files, 1389 tests)
- [x] I tested the change locally with `bun run tauri:dev` (app launches under `DISPLAY=:1`, main window renders)

Additional checks:
- `cargo test -p crossusage-cli` — 5 passed
- `cargo run -p crossusage-cli -- list` / `probe mock` — engine works end-to-end
- `cargo test -p crossusage-core` — 104 passed, 2 failed (`ccusage_runner_retries_legacy_package_when_current_package_fails`, `ccusage_timeout_kills_descendant_and_closes_pipes`); both spawn subprocesses with `process_group(0)` and fail only in this sandboxed microVM. They are outside CI scope (CI runs `bun run test` + `cargo test -p crossusage-cli`).

## Screenshots

Onboarding layout selection:

[CrossUsage onboarding layout selection](https://cursor.com/agents/bc-850d2407-f7ea-4e26-a0f0-39a33f71c694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcrossusage_onboarding_layout.webp)

Main panel showing the built-in `mock` provider with live usage progress bars (hello-world action — usage fetched via the plugin engine, no credentials needed):

[CrossUsage main panel with mock provider usage bars](https://cursor.com/agents/bc-850d2407-f7ea-4e26-a0f0-39a33f71c694/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcrossusage_main_panel_usage.webp)

## Checklist

- [x] I did not introduce new dependencies without justification (docs-only code change)
- [ ] My PR targets the `main` branch (targets `feat/linux-windows-native-support`, the active fork branch)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-850d2407-f7ea-4e26-a0f0-39a33f71c694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-850d2407-f7ea-4e26-a0f0-39a33f71c694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

