### PR TITLE
Release 1.3.1 — multi-account for all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Linux **CLI-only** without a desktop package: add `INSTALL_MODE=cli` to the firs
 
 ## Providers
 
-Multi-account OAuth rows: **[multi-account credentials](docs/providers/multi-account-credentials.md)**.
+- **Multi-account for all providers** — add Work/personal rows per provider in Settings (API keys + OAuth); credentials encrypted at rest. See **[multi-account credentials](docs/providers/multi-account-credentials.md)**.
 
 | Provider | Docs |
 |----------|------|


### PR DESCRIPTION
## Summary

Merges **1.3.1** into the integration branch `feat/linux-windows-native-support` (not `main` — avoids conflicts with upstream OpenUsage history on fork `main`).

### Highlights
- **Multi-account for all providers** — Settings → Add account / Set credentials on every bundled provider except Mock; AES-256-GCM encrypted `provider_accounts.json` with OS keychain master key
- OpenUsage **v0.7.2 + v0.7.3** port: native Claude/Codex scanners, model pricing, spend hover, provider fixes
- Modern UI: `::` metric IDs, instance ordering under parent provider, `cursor:work` probe bootstrap fix
- Docs: [multi-account-credentials.md](docs/providers/multi-account-credentials.md) rewritten

**Release:** https://github.com/barramee27/crossusage/releases/tag/v1.3.1

## Test plan

- [x] Frontend unit tests (`bun run test` — 1408 passed)
- [x] `bun run tauri:dev` — multi-account UI; `cursor:work` probe bootstrap fix
- [x] Linux `.deb` / `.rpm` / AppImage built locally
- [x] Windows NSIS installer + onefile portable built locally
- [x] Tauri updater: `latest.json` + `.sig` for `.deb` and NSIS

Made with [Cursor](https://cursor.com)