### PR TITLE
fix(polls): close Aptabase poll Saturday (server-only)

### DIFF
--- a/deploy/crossusage.dev/polls-api/README.md
+++ b/deploy/crossusage.dev/polls-api/README.md
@@ -19,7 +19,7 @@ Client IP from nginx `X-Real-IP` (hashed before store). VPNs still bypass IP cap
 
 | Method | Path | Notes |
 |--------|------|-------|
-| GET | `/api/polls/active?appVersion=1.4.0` | Active poll JSON, or **204** if none |
+| GET | `/api/polls/active?appVersion=1.4.0` | Published poll JSON (`active: true`), or **204** if none. Expired/`ended` polls still return so results stay visible until you set `active: false`. New votes after `expiresAt` → **410**. |
 | POST | `/api/polls/:id/vote` | `{ installId, optionId }` → `{ ok, results }` or `429` |
 | POST | `/api/polls/:id/dismiss` | `{ installId, reason: "not_now" \| "dont_ask" }` → `{ ok }` |
 | GET | `/api/polls/:id/results?installId=` | **Vote counts only** (after vote, or poll ended). No dismissals. |
@@ -46,7 +46,7 @@ POLLS_ADMIN_TOKEN=dev-secret bun run server.ts
 # → http://127.0.0.1:6740/api/polls/active
 ```
 
-Flip `"active": true` on a file in `polls/` to publish.
+Flip `"active": true` on a file in `polls/` to publish. Set `"expiresAt": "2026-08-15T23:59:59.000Z"` (ISO UTC) so the poll closes; put the same date in `body` so the app description shows it. After expiry the poll stays on `/active` with `ended: true` (winner/results) until `"active": false`.
 
 ## VPS install
 

--- a/deploy/crossusage.dev/polls-api/polls/aptabase-extra-2026-08.json
+++ b/deploy/crossusage.dev/polls-api/polls/aptabase-extra-2026-08.json
@@ -1,0 +1,16 @@
+{
+  "id": "aptabase-extra-2026-08",
+  "version": 2,
+  "title": "OK to send a bit more anonymous product data?",
+  "body": "Today Aptabase only sees that CrossUsage opened (about once per day). With your OK, we'd also send: UI mode (Classic / Modern) and which providers you have enabled — never credentials, never usage totals or spend, never account email. Used only to decide what to build next. You can still turn all product polls off in Settings. This poll closes Saturday, 15 August 2026, 23:59 UTC.",
+  "options": [
+    { "id": "yes_ui_providers", "label": "Yes — UI + enabled providers is fine" },
+    { "id": "providers_only", "label": "Enabled providers only (not UI)" },
+    { "id": "no", "label": "No — keep app_started only" }
+  ],
+  "allowDismiss": true,
+  "minAppVersion": "1.4.0",
+  "expiresAt": "2026-08-15T23:59:59.000Z",
+  "active": true,
+  "ended": false
+}

--- a/deploy/crossusage.dev/polls-api/server.test.ts
+++ b/deploy/crossusage.dev/polls-api/server.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, test } from "bun:test"
 import {
   checkBurst,
   clientIp,
+  isExpired,
   isValidDismissReason,
   isValidInstallId,
+  selectActivePoll,
   versionSatisfies,
+  type PollDef,
 } from "./server.ts"
 
 describe("polls-api anti-spam helpers", () => {
@@ -45,5 +48,59 @@ describe("polls-api anti-spam helpers", () => {
   test("versionSatisfies", () => {
     expect(versionSatisfies("1.4.0", "1.0.0")).toBe(true)
     expect(versionSatisfies("0.9.0", "1.0.0")).toBe(false)
+  })
+})
+
+function poll(over: Partial<PollDef> & Pick<PollDef, "id">): PollDef {
+  return {
+    title: "T",
+    options: [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+    ],
+    active: true,
+    ended: false,
+    ...over,
+  }
+}
+
+describe("selectActivePoll", () => {
+  const now = Date.parse("2026-08-13T12:00:00.000Z")
+
+  test("isExpired is false when expiresAt is missing", () => {
+    expect(isExpired(undefined, now)).toBe(false)
+  })
+
+  test("isExpired is true at/after expiresAt", () => {
+    expect(isExpired("2026-08-15T23:59:59.000Z", now)).toBe(false)
+    expect(isExpired("2026-08-15T23:59:59.000Z", Date.parse("2026-08-15T23:59:59.000Z"))).toBe(true)
+    expect(isExpired("2026-08-15T23:59:59.000Z", Date.parse("2026-08-16T00:00:00.000Z"))).toBe(true)
+  })
+
+  test("returns open poll", () => {
+    const p = poll({ id: "open", expiresAt: "2026-08-15T23:59:59.000Z" })
+    expect(selectActivePoll([p], "1.4.0", now)?.id).toBe("open")
+  })
+
+  test("keeps expired published poll so winner stays visible", () => {
+    const p = poll({ id: "done", expiresAt: "2026-08-15T23:59:59.000Z" })
+    const after = Date.parse("2026-08-16T00:00:00.000Z")
+    expect(selectActivePoll([p], "1.4.0", after)?.id).toBe("done")
+  })
+
+  test("keeps ended:true published poll", () => {
+    const p = poll({ id: "ended", ended: true })
+    expect(selectActivePoll([p], "1.4.0", now)?.id).toBe("ended")
+  })
+
+  test("prefers an open poll over an expired one", () => {
+    const expired = poll({ id: "old", expiresAt: "2026-08-01T00:00:00.000Z" })
+    const open = poll({ id: "new", expiresAt: "2026-09-01T00:00:00.000Z" })
+    expect(selectActivePoll([expired, open], "1.4.0", now)?.id).toBe("new")
+  })
+
+  test("hides polls with active:false", () => {
+    const p = poll({ id: "hidden", active: false })
+    expect(selectActivePoll([p], "1.4.0", now)).toBeNull()
   })
 })

--- a/deploy/crossusage.dev/polls-api/server.ts
+++ b/deploy/crossusage.dev/polls-api/server.ts
@@ -28,8 +28,8 @@ const VOTE_BURST_WINDOW_MS = Math.max(1000, Number(process.env.POLLS_VOTE_BURST_
 const DISMISS_REASONS = ["not_now", "dont_ask"] as const
 export type DismissReason = (typeof DISMISS_REASONS)[number]
 
-type PollOption = { id: string; label: string }
-type PollDef = {
+export type PollOption = { id: string; label: string }
+export type PollDef = {
   id: string
   version?: number
   title: string
@@ -154,7 +154,7 @@ export function versionSatisfies(appVersion: string | null, minVersion: string |
   return true
 }
 
-function isExpired(expiresAt: string | undefined, now = Date.now()): boolean {
+export function isExpired(expiresAt: string | undefined, now = Date.now()): boolean {
   if (!expiresAt) return false
   const t = Date.parse(expiresAt)
   return Number.isFinite(t) && t <= now
@@ -178,16 +178,25 @@ function loadPollDefs(): PollDef[] {
   return out
 }
 
-function getActivePoll(appVersion: string | null): PollDef | null {
-  const now = Date.now()
-  const candidates = loadPollDefs().filter(
-    (p) =>
-      p.active === true &&
-      !p.ended &&
-      !isExpired(p.expiresAt, now) &&
-      versionSatisfies(appVersion, p.minAppVersion),
+/**
+ * Published poll for GET /active.
+ * Open polls win; if none, keep the published ended/expired poll so results + winner stay visible.
+ * Set `"active": false` to hide it. `expiresAt` / `ended` stop new votes (410).
+ */
+export function selectActivePoll(
+  polls: PollDef[],
+  appVersion: string | null,
+  now = Date.now(),
+): PollDef | null {
+  const published = polls.filter(
+    (p) => p.active === true && versionSatisfies(appVersion, p.minAppVersion),
   )
-  return candidates[0] ?? null
+  const open = published.filter((p) => !p.ended && !isExpired(p.expiresAt, now))
+  return open[0] ?? published[0] ?? null
+}
+
+function getActivePoll(appVersion: string | null): PollDef | null {
+  return selectActivePoll(loadPollDefs(), appVersion)
 }
 
 function getPollById(id: string): PollDef | null {
@@ -352,7 +361,7 @@ async function handleRequest(req: Request): Promise<Response> {
     const poll = getActivePoll(appVersion)
     if (!poll) return empty(204)
     return json(publicPoll(poll), 200, {
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "public, max-age=60",
     })
   }
 

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -1,5 +1,9 @@
 # Breadcrumbs
 
+## 2026-08-13
+
+- Live poll `aptabase-extra-2026-08`: `expiresAt` 2026-08-15T23:59:59Z + close date in body. `selectActivePoll` keeps expired/ended published polls on `/active` for results. `/active` cache 60s; client fetch `cache: "no-store"`.
+
 ## 2026-08-09
 
 - Polls dismiss telemetry (`not_now`/`dont_ask`) + admin `GET /api/polls/:id/stats`; public results stay vote-only.

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -2,7 +2,7 @@
 
 ## 2026-08-13
 
-- Live poll `aptabase-extra-2026-08`: `expiresAt` 2026-08-15T23:59:59Z + close date in body. `selectActivePoll` keeps expired/ended published polls on `/active` for results. `/active` cache 60s; client fetch `cache: "no-store"`.
+- Live poll `aptabase-extra-2026-08`: `expiresAt` 2026-08-15T23:59:59Z + close date in body. `selectActivePoll` keeps expired/ended published polls on `/active` for results. `/active` cache 60s. Server-only — 1.4.0 clients already render `body` + `ended`.
 
 ## 2026-08-09
 

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -1,5 +1,9 @@
 # Choices
 
+## 2026-08-13
+
+- **Aptabase poll close:** Saturday **15 Aug 2026, 23:59 UTC** (`expiresAt`). Same sentence in `body`. After expiry, `/active` still returns the poll (`ended: true`) so a winner can show; set `active: false` to hide. Open poll preferred if several are published.
+
 ## 2026-08-09
 
 - **Polls dismiss telemetry:** app POSTs `not_now` / `dont_ask`; admin-only `GET …/stats` via `X-Polls-Admin`. Public results stay vote-only.

--- a/src/lib/product-polls.ts
+++ b/src/lib/product-polls.ts
@@ -153,7 +153,7 @@ export async function fetchActiveProductPoll(args: {
   try {
     const res = await fetchWithTimeout(
       url,
-      { method: "GET", headers: { Accept: "application/json" }, cache: "no-store" },
+      { method: "GET", headers: { Accept: "application/json" } },
       args.timeoutMs ?? PRODUCT_POLLS_FETCH_TIMEOUT_MS,
     )
     if (res.status === 204) return { ok: true, poll: null }

--- a/src/lib/product-polls.ts
+++ b/src/lib/product-polls.ts
@@ -153,7 +153,7 @@ export async function fetchActiveProductPoll(args: {
   try {
     const res = await fetchWithTimeout(
       url,
-      { method: "GET", headers: { Accept: "application/json" } },
+      { method: "GET", headers: { Accept: "application/json" }, cache: "no-store" },
       args.timeoutMs ?? PRODUCT_POLLS_FETCH_TIMEOUT_MS,
     )
     if (res.status === 204) return { ok: true, poll: null }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Server-only. **No app update.** 1.4.0 already fetches `/api/polls/active` and shows `body` + `ended`.

Live poll `aptabase-extra-2026-08`:
- `expiresAt`: `2026-08-15T23:59:59.000Z` (Saturday 23:59 UTC)
- Same close date in the poll **description** (`body`)
- After close, `/active` still returns the poll with `ended: true` so a winner/results can show. New votes → 410. Hide later with `"active": false`.

Already deployed on the VPS.

## Related Issue

n/a — follow-up to 1.4.0 polls (null `expiresAt` would keep the poll open forever)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [ ] I ran `bun run build` and it succeeded
- [x] I ran `bun test` in `deploy/crossusage.dev/polls-api` (12 pass)
- [ ] I tested the change locally with `bun tauri dev`

Verified live: `GET https://crossusage.dev/api/polls/active?appVersion=1.4.0` now has `expiresAt` and the Saturday close sentence in `body`.

## Screenshots

n/a — no UI code change

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] My PR targets the `main` branch
- [x] I did not introduce new dependencies without justification

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff933-f359-7899-a832-901b5f8a127c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff933-f359-7899-a832-901b5f8a127c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

