### PR TITLE
feat: port OpenUsage v0.7.8–v0.7.9 for CrossUsage 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 **CrossUsage** ships **1.x** releases from [github.com/barramee27/crossusage](https://github.com/barramee27/crossusage). Older **0.6.x** sections below are **archived OpenUsage upstream** notes, not CrossUsage release numbers.
 
+## 1.4.1
+
+**Theme:** OpenUsage **v0.7.8 + v0.7.9** upstream patch (PATCH per [docs/VERSIONING.md](docs/VERSIONING.md)). Robin skipped a public **v0.7.7**. Port tracker: [docs/PORT-0.7.8-0.7.9.md](docs/PORT-0.7.8-0.7.9.md).
+
+### New features
+
+- **Reduce animations** — Settings toggle hard-kills panel motion (#1019). Motion on: aurora, orbs, scanline, cursor comet, bar sparks. No live 3D/zoom, concentric grain rings, or click ripples.
+- **Reset all settings** — confirmation in Advanced; restores UI prefs without wiping credentials or poll votes (#1033).
+
+### Bug fixes
+
+- **Pricing** — Kimi K3, Cursor Router labels, Claude Opus 5, Daybreak Blue, Grok 4.6; Grok 4.5 Fast output $12/MTok (#1087, #1050, #1093, #1101). Supplement `updated_at` **2026-08-13**.
+- **Codex auto-review** — keep the `codex-auto-review` slug in breakdowns; dated fallback model is used only for cost (#1085).
+- **OpenCode Go** — Session/Weekly/Monthly from `GET /zen/go/v1/usage` when a Go key exists; local SQLite only without a key (#1097).
+
+Skipped: Account-first Phase 2/2b (reverted upstream #1090), PostHog/Sparkle/stale, JSONL disk cache (#1017 later), live pricing fetch (#1089 — fork bundled-only).
+
+---
+
 ## 1.4.0
 
 **Theme:** Fork MINOR — product polls, Windows Antigravity CLI keyring fix, new-provider-on-update notify, machine-readable limits.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "crossusage"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "base64 0.22.1",
  "crossusage-core",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "crossusage-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "crossusage-core"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/crates/crossusage-cli/Cargo.toml
+++ b/crates/crossusage-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossusage-cli"
-version = "1.4.0"
+version = "1.4.1"
 description = "CrossUsage CLI — terminal interface for the same plugin engine as the GUI"
 edition = "2021"
 

--- a/crates/crossusage-core/Cargo.toml
+++ b/crates/crossusage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossusage-core"
-version = "1.4.0"
+version = "1.4.1"
 description = "Shared plugin engine for CrossUsage (GUI + CLI)"
 edition = "2024"
 

--- a/crates/crossusage-core/data/pricing_supplement.json
+++ b/crates/crossusage-core/data/pricing_supplement.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries.",
-  "updated_at": "2026-07-14",
+  "$comment": "OpenUsage pricing supplement. Prices Cursor-native models that no public catalog carries, supplies fast-variant multipliers the catalogs omit, and maps provider log/CSV model slugs to canonical pricing keys (LiteLLM keys, models.dev ids, or entries in this file). Cursor Router rows name the routed model in prose instead of a slug ('Opus 5 (Auto Balanced)'), so those labels get alias rules too. Published to gh-pages by .github/workflows/pricing-supplement.yml on every change, so installed apps pick edits up within about an hour - no release needed. Rates are USD per million tokens. Sources: https://cursor.com/docs/models-and-pricing.md for Cursor-native entries; https://developers.openai.com/api/docs/models/daybreak-blue-latest and https://developers.openai.com/api/docs/pricing for Daybreak aliases and rates.",
+  "updated_at": "2026-08-13T07:45:58Z",
   "pricing": {
     "auto": {
       "input_per_million": 1.25,
@@ -61,7 +61,20 @@
       "input_per_million": 4.0,
       "cache_write_per_million": 4.0,
       "cache_read_per_million": 1.0,
-      "output_per_million": 18.0
+      "output_per_million": 12.0
+    },
+    "grok-4.6": {
+      "$comment": "Cursor + SpaceXAI first-party model. Cache write not published separately; defaults to input. Cursor lists a 50% launch discount for one week starting 2026-08-12; rates below are the numbers on the pricing table as of 2026-08-13.",
+      "input_per_million": 2.0,
+      "cache_write_per_million": 2.0,
+      "cache_read_per_million": 0.5,
+      "output_per_million": 6.0
+    },
+    "grok-4.6-fast": {
+      "input_per_million": 4.0,
+      "cache_write_per_million": 4.0,
+      "cache_read_per_million": 1.0,
+      "output_per_million": 12.0
     },
     "kimi-k2.7-code": {
       "$comment": "Cursor's published Kimi K2.7 Code rates. Public catalogs disagree (some bare keys are $0), so this override wins.",
@@ -69,6 +82,13 @@
       "cache_write_per_million": 0.95,
       "cache_read_per_million": 0.19,
       "output_per_million": 4.0
+    },
+    "kimi-k3": {
+      "$comment": "Cursor's published Kimi K3 rates (Moonshot). Cursor lists no separate cache-write fee, so cache writes bill at the input rate, same as the Kimi K2.7 Code entry. Neither LiteLLM nor models.dev carries the model.",
+      "input_per_million": 3.0,
+      "cache_write_per_million": 3.0,
+      "cache_read_per_million": 0.3,
+      "output_per_million": 15.0
     },
     "claude-opus-4-7-fast": {
       "$comment": "Cursor bills Opus 4.7 fast mode at these rates; the models.dev entry carries higher (stale) numbers, so this override wins.",
@@ -79,6 +99,20 @@
     },
     "claude-opus-4-8-fast": {
       "$comment": "Cursor states Opus 4.8 fast mode is 3x lower per-token than Opus 4.7 fast mode (= 2x the Opus 4.8 base rate, matching LiteLLM's fast multiplier); the models.dev entry disagrees, so this override wins.",
+      "input_per_million": 10.0,
+      "cache_write_per_million": 12.5,
+      "cache_read_per_million": 1.0,
+      "output_per_million": 50.0
+    },
+    "claude-opus-5": {
+      "$comment": "Claude Opus 5 launch pricing per anthropic.com/news/claude-opus-5: $5 input / $25 output per million, plus the standard Anthropic cache multipliers (1.25x 5m cache write, 0.1x cache read). LiteLLM, models.dev, and Cursor have not listed the model yet, so it would otherwise show as an unpriced model.",
+      "input_per_million": 5.0,
+      "cache_write_per_million": 6.25,
+      "cache_read_per_million": 0.5,
+      "output_per_million": 25.0
+    },
+    "claude-opus-5-fast": {
+      "$comment": "Opus 5 fast mode: the launch announcement prices it at twice the Opus 5 base rate, matching the fast multiplier already used for Opus 4.8.",
       "input_per_million": 10.0,
       "cache_write_per_million": 12.5,
       "cache_read_per_million": 1.0,
@@ -112,6 +146,7 @@
     }
   },
   "fast_multipliers": {
+    "claude-opus-5": 2.0,
     "gpt-5": 2.0,
     "gpt-5.1-codex": 2.0,
     "gpt-5.1-codex-max": 2.0,
@@ -125,313 +160,110 @@
     "gpt-5.6-luna": 2.5
   },
   "alias_rules": [
-    {
-      "pattern": "^agent_review$",
-      "canonical": "gpt-5.4"
-    },
-    {
-      "pattern": "^default$",
-      "canonical": "auto"
-    },
-    {
-      "pattern": "^auto$",
-      "canonical": "auto"
-    },
-    {
-      "pattern": "^composer-1$",
-      "canonical": "composer-1"
-    },
-    {
-      "pattern": "^composer-1\\.5$",
-      "canonical": "composer-1.5"
-    },
-    {
-      "pattern": "^composer-2$",
-      "canonical": "composer-2"
-    },
-    {
-      "pattern": "^composer-2-fast$",
-      "canonical": "composer-2-fast"
-    },
-    {
-      "pattern": "^composer-2\\.5$",
-      "canonical": "composer-2.5"
-    },
-    {
-      "pattern": "^composer-2\\.5-fast$",
-      "canonical": "composer-2.5-fast"
-    },
-    {
-      "pattern": "^github_bugbot$",
-      "canonical": "github_bugbot"
-    },
-    {
-      "pattern": "^(?:cursor-)?grok-4\\.5-fast(?:-(?:low|medium|high|xhigh))?$",
-      "canonical": "grok-4.5-fast"
-    },
-    {
-      "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?-fast$",
-      "canonical": "grok-4.5-fast"
-    },
-    {
-      "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?$",
-      "canonical": "grok-4.5"
-    },
-    {
-      "pattern": "^kimi-k2\\.7(?:-code)?$",
-      "canonical": "kimi-k2.7-code"
-    },
-    {
-      "pattern": "^kimi-k2p7(?:-code)?$",
-      "canonical": "kimi-k2.7-code"
-    },
-    {
-      "pattern": "^claude-4\\.5-haiku(?:-thinking)?$",
-      "canonical": "claude-haiku-4-5"
-    },
-    {
-      "pattern": "^claude-4\\.5-opus-(?:low|medium|high)(?:-thinking)?$",
-      "canonical": "claude-opus-4-5"
-    },
-    {
-      "pattern": "^claude-4-sonnet-1m(?:-thinking)?$",
-      "canonical": "claude-4-sonnet-1m"
-    },
-    {
-      "pattern": "^claude-4-sonnet(?:-thinking)?$",
-      "canonical": "claude-sonnet-4-20250514"
-    },
-    {
-      "pattern": "^claude-4\\.5-sonnet(?:-thinking)?$",
-      "canonical": "claude-sonnet-4-5"
-    },
-    {
-      "pattern": "^claude-4\\.6-sonnet(?:-(?:low|medium|high|xhigh|max))?(?:-thinking)?$",
-      "canonical": "claude-sonnet-4-6"
-    },
-    {
-      "pattern": "^claude-4\\.6-opus-(?:low|medium|high|max)(?:-thinking)?-fast$",
-      "canonical": "claude-opus-4-6-fast"
-    },
-    {
-      "pattern": "^claude-4\\.6-opus-(?:low|medium|high|max)(?:-thinking)?$",
-      "canonical": "claude-opus-4-6"
-    },
-    {
-      "pattern": "^claude-4\\.7-opus-(?:low|medium|high|max)(?:-thinking)?-fast$",
-      "canonical": "claude-opus-4-7-fast"
-    },
-    {
-      "pattern": "^claude-4\\.7-opus-(?:low|medium|high|max)(?:-thinking)?$",
-      "canonical": "claude-opus-4-7"
-    },
-    {
-      "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$",
-      "canonical": "claude-opus-4-7-fast"
-    },
-    {
-      "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$",
-      "canonical": "claude-opus-4-7"
-    },
-    {
-      "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$",
-      "canonical": "claude-opus-4-8-fast"
-    },
-    {
-      "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$",
-      "canonical": "claude-opus-4-8"
-    },
-    {
-      "pattern": "^claude-fable-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$",
-      "canonical": "claude-fable-5"
-    },
-    {
-      "pattern": "^claude-sonnet-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$",
-      "canonical": "claude-sonnet-5"
-    },
-    {
-      "pattern": "^gemini-2\\.5-flash$",
-      "canonical": "gemini-2.5-flash"
-    },
-    {
-      "pattern": "^gemini-3-flash(?:-preview)?$",
-      "canonical": "gemini-3-flash-preview"
-    },
-    {
-      "pattern": "^gemini-3\\.5-flash(?:-preview)?$",
-      "canonical": "gemini-3.5-flash"
-    },
-    {
-      "pattern": "^gemini-3-pro-preview$",
-      "canonical": "gemini-3-pro-preview"
-    },
-    {
-      "pattern": "^gemini-3\\.1-pro$",
-      "canonical": "gemini-3.1-pro-preview"
-    },
-    {
-      "pattern": "^gemini-3\\.1-pro-preview$",
-      "canonical": "gemini-3.1-pro-preview"
-    },
-    {
-      "pattern": "^gpt-5(?:-(?:low|high))?-fast$",
-      "canonical": "gpt-5-fast"
-    },
-    {
-      "pattern": "^gpt-5(?:-(?:low|high))?$",
-      "canonical": "gpt-5"
-    },
-    {
-      "pattern": "^gpt-5\\.1(?:-(?:low|high))?-fast$",
-      "canonical": "gpt-5-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.1(?:-(?:low|high))?$",
-      "canonical": "gpt-5"
-    },
-    {
-      "pattern": "^gpt-5-mini$",
-      "canonical": "gpt-5-mini"
-    },
-    {
-      "pattern": "^grok-4-20(?:-thinking)?$",
-      "canonical": "xai/grok-4.20-0309-reasoning"
-    },
-    {
-      "pattern": "^grok-4\\.3(?:-thinking)?$",
-      "canonical": "xai/grok-4.3"
-    },
-    {
-      "pattern": "^grok-build-0\\.1$",
-      "canonical": "grok-build-0.1"
-    },
-    {
-      "pattern": "^grok-code-fast-1$",
-      "canonical": "grok-build-0.1"
-    },
-    {
-      "pattern": "^grok-build$",
-      "canonical": "grok-build-0.1"
-    },
-    {
-      "pattern": "^grok-composer-2\\.5-fast$",
-      "canonical": "composer-2.5-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.1-codex-max(?:-(?:low|medium|high|xhigh))?-fast$",
-      "canonical": "gpt-5.1-codex-max-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.1-codex-max(?:-(?:low|medium|high|xhigh))?$",
-      "canonical": "gpt-5.1-codex-max"
-    },
-    {
-      "pattern": "^gpt-5\\.1-codex-mini(?:-(?:low|medium|high|xhigh))?$",
-      "canonical": "gpt-5.1-codex-mini"
-    },
-    {
-      "pattern": "^gpt-5\\.1-codex(?:-(?:low|medium|high|xhigh))?-fast$",
-      "canonical": "gpt-5.1-codex-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.1-codex(?:-(?:low|medium|high|xhigh))?$",
-      "canonical": "gpt-5.1-codex"
-    },
-    {
-      "pattern": "^gpt-5\\.2-codex(?:-(?:low|high|xhigh))?-fast$",
-      "canonical": "gpt-5.2-codex-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.2-codex(?:-(?:low|high|xhigh))?$",
-      "canonical": "gpt-5.2-codex"
-    },
-    {
-      "pattern": "^gpt-5\\.2(?:-(?:low|high|xhigh))?-fast$",
-      "canonical": "gpt-5.2-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.2(?:-(?:low|high|xhigh))?$",
-      "canonical": "gpt-5.2"
-    },
-    {
-      "pattern": "^gpt-5\\.3-codex-spark-preview(?:-(?:low|high|xhigh))?$",
-      "canonical": "gpt-5.3-codex-spark"
-    },
-    {
-      "pattern": "^gpt-5\\.3-spark$",
-      "canonical": "gpt-5.3-codex-spark"
-    },
-    {
-      "pattern": "^gpt-5\\.3-codex(?:-(?:low|high|xhigh))?-fast$",
-      "canonical": "gpt-5.3-codex-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.3-codex(?:-(?:low|high|xhigh))?$",
-      "canonical": "gpt-5.3-codex"
-    },
-    {
-      "pattern": "^gpt-5\\.4-mini(?:-(?:none|low|medium|high|xhigh))?$",
-      "canonical": "gpt-5.4-mini"
-    },
-    {
-      "pattern": "^gpt-5\\.4-nano(?:-(?:none|low|medium|high|xhigh))?$",
-      "canonical": "gpt-5.4-nano"
-    },
-    {
-      "pattern": "^gpt-5\\.4-(?:low|medium|high|xhigh)-fast$",
-      "canonical": "gpt-5.4-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.4-(?:low|medium|high|xhigh)$",
-      "canonical": "gpt-5.4"
-    },
-    {
-      "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?-fast$",
-      "canonical": "gpt-5.5-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?$",
-      "canonical": "gpt-5.5"
-    },
-    {
-      "pattern": "^gpt-5\\.6-sol(?:-(?:none|low|medium|high|xhigh|max|ultra))?-fast$",
-      "canonical": "gpt-5.6-sol-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.6-sol(?:-(?:none|low|medium|high|xhigh|max|ultra))?$",
-      "canonical": "gpt-5.6-sol"
-    },
-    {
-      "pattern": "^gpt-5\\.6-terra(?:-(?:none|low|medium|high|xhigh|max))?-fast$",
-      "canonical": "gpt-5.6-terra-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.6-terra(?:-(?:none|low|medium|high|xhigh|max))?$",
-      "canonical": "gpt-5.6-terra"
-    },
-    {
-      "pattern": "^gpt-5\\.6-luna(?:-(?:none|low|medium|high|xhigh|max))?-fast$",
-      "canonical": "gpt-5.6-luna-fast"
-    },
-    {
-      "pattern": "^gpt-5\\.6-luna(?:-(?:none|low|medium|high|xhigh|max))?$",
-      "canonical": "gpt-5.6-luna"
-    },
-    {
-      "pattern": "^kimi-k2\\.5$",
-      "canonical": "moonshot/kimi-k2.5"
-    },
-    {
-      "pattern": "^kimi-k2p5$",
-      "canonical": "moonshot/kimi-k2.5"
-    },
-    {
-      "pattern": "^glm-5\\.2(?:-(?:high|max))?$",
-      "canonical": "glm-5.2"
-    },
-    {
-      "pattern": "^[Pp]remium \\((?:[Gg][Pp][Tt]-5\\.3-[Cc]odex|[Cc]odex 5\\.3)\\)$",
-      "canonical": "gpt-5.3-codex"
-    }
+    { "pattern": "^agent_review$", "canonical": "gpt-5.4" },
+    { "pattern": "^default$", "canonical": "auto" },
+    { "pattern": "^auto$", "canonical": "auto" },
+    { "pattern": "^composer$", "canonical": "composer-2.5" },
+    { "pattern": "^composer-1$", "canonical": "composer-1" },
+    { "pattern": "^composer-1\\.5$", "canonical": "composer-1.5" },
+    { "pattern": "^composer-2$", "canonical": "composer-2" },
+    { "pattern": "^composer-2-fast$", "canonical": "composer-2-fast" },
+    { "pattern": "^composer-2\\.5$", "canonical": "composer-2.5" },
+    { "pattern": "^composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
+    { "pattern": "^github_bugbot$", "canonical": "github_bugbot" },
+    { "pattern": "^(?:cursor-)?grok-4\\.6-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.6(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.6-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.6(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.6" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5-fast(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "grok-4.5-fast" },
+    { "pattern": "^(?:cursor-)?grok-4\\.5(?:-(?:low|medium|high|xhigh))?$", "canonical": "grok-4.5" },
+    { "pattern": "^kimi-k2\\.7(?:-code)?$", "canonical": "kimi-k2.7-code" },
+    { "pattern": "^kimi-k2p7(?:-code)?$", "canonical": "kimi-k2.7-code" },
+    { "pattern": "^kimi-k3(?:-code)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "kimi-k3" },
+    { "pattern": "^claude-4\\.5-haiku(?:-thinking)?$", "canonical": "claude-haiku-4-5" },
+    { "pattern": "^claude-4\\.5-opus-(?:low|medium|high)(?:-thinking)?$", "canonical": "claude-opus-4-5" },
+    { "pattern": "^claude-4-sonnet-1m(?:-thinking)?$", "canonical": "claude-4-sonnet-1m" },
+    { "pattern": "^claude-4-sonnet(?:-thinking)?$", "canonical": "claude-sonnet-4-20250514" },
+    { "pattern": "^claude-4\\.5-sonnet(?:-thinking)?$", "canonical": "claude-sonnet-4-5" },
+    { "pattern": "^claude-4\\.6-sonnet(?:-(?:low|medium|high|xhigh|max))?(?:-thinking)?$", "canonical": "claude-sonnet-4-6" },
+    { "pattern": "^claude-4\\.6-opus-(?:low|medium|high|max)(?:-thinking)?-fast$", "canonical": "claude-opus-4-6-fast" },
+    { "pattern": "^claude-4\\.6-opus-(?:low|medium|high|max)(?:-thinking)?$", "canonical": "claude-opus-4-6" },
+    { "pattern": "^claude-4\\.7-opus-(?:low|medium|high|max)(?:-thinking)?-fast$", "canonical": "claude-opus-4-7-fast" },
+    { "pattern": "^claude-4\\.7-opus-(?:low|medium|high|max)(?:-thinking)?$", "canonical": "claude-opus-4-7" },
+    { "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-4-7-fast" },
+    { "pattern": "^claude-opus-4-7(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-4-7" },
+    { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-4-8-fast" },
+    { "pattern": "^claude-opus-4-8(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-4-8" },
+    { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?-fast$", "canonical": "claude-opus-5-fast" },
+    { "pattern": "^claude-opus-5(?:\\[1m\\])?(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-opus-5" },
+    { "pattern": "^claude-fable-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-fable-5" },
+    { "pattern": "^claude-sonnet-5(?:-thinking)?(?:-(?:low|medium|high|xhigh|max))?$", "canonical": "claude-sonnet-5" },
+    { "pattern": "^gemini-2\\.5-flash$", "canonical": "gemini-2.5-flash" },
+    { "pattern": "^gemini-3-flash(?:-preview)?$", "canonical": "gemini-3-flash-preview" },
+    { "pattern": "^gemini-3\\.5-flash(?:-preview)?$", "canonical": "gemini-3.5-flash" },
+    { "pattern": "^gemini-3-pro-preview$", "canonical": "gemini-3-pro-preview" },
+    { "pattern": "^gemini-3\\.1-pro$", "canonical": "gemini-3.1-pro-preview" },
+    { "pattern": "^gemini-3\\.1-pro-preview$", "canonical": "gemini-3.1-pro-preview" },
+    { "pattern": "^gpt-5(?:-(?:low|high))?-fast$", "canonical": "gpt-5-fast" },
+    { "pattern": "^gpt-5(?:-(?:low|high))?$", "canonical": "gpt-5" },
+    { "pattern": "^gpt-5\\.1(?:-(?:low|high))?-fast$", "canonical": "gpt-5-fast" },
+    { "pattern": "^gpt-5\\.1(?:-(?:low|high))?$", "canonical": "gpt-5" },
+    { "pattern": "^gpt-5-mini$", "canonical": "gpt-5-mini" },
+    { "pattern": "^grok-4-20(?:-thinking)?$", "canonical": "xai/grok-4.20-0309-reasoning" },
+    { "pattern": "^grok-4\\.3(?:-thinking)?$", "canonical": "xai/grok-4.3" },
+    { "pattern": "^grok-build-0\\.1$", "canonical": "grok-build-0.1" },
+    { "pattern": "^grok-code-fast-1$", "canonical": "grok-build-0.1" },
+    { "pattern": "^grok-build$", "canonical": "grok-build-0.1" },
+    { "pattern": "^grok-composer-2\\.5-fast$", "canonical": "composer-2.5-fast" },
+    { "pattern": "^gpt-5\\.1-codex-max(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "gpt-5.1-codex-max-fast" },
+    { "pattern": "^gpt-5\\.1-codex-max(?:-(?:low|medium|high|xhigh))?$", "canonical": "gpt-5.1-codex-max" },
+    { "pattern": "^gpt-5\\.1-codex-mini(?:-(?:low|medium|high|xhigh))?$", "canonical": "gpt-5.1-codex-mini" },
+    { "pattern": "^gpt-5\\.1-codex(?:-(?:low|medium|high|xhigh))?-fast$", "canonical": "gpt-5.1-codex-fast" },
+    { "pattern": "^gpt-5\\.1-codex(?:-(?:low|medium|high|xhigh))?$", "canonical": "gpt-5.1-codex" },
+    { "pattern": "^gpt-5\\.2-codex(?:-(?:low|high|xhigh))?-fast$", "canonical": "gpt-5.2-codex-fast" },
+    { "pattern": "^gpt-5\\.2-codex(?:-(?:low|high|xhigh))?$", "canonical": "gpt-5.2-codex" },
+    { "pattern": "^gpt-5\\.2(?:-(?:low|high|xhigh))?-fast$", "canonical": "gpt-5.2-fast" },
+    { "pattern": "^gpt-5\\.2(?:-(?:low|high|xhigh))?$", "canonical": "gpt-5.2" },
+    { "pattern": "^gpt-5\\.3-codex-spark-preview(?:-(?:low|high|xhigh))?$", "canonical": "gpt-5.3-codex-spark" },
+    { "pattern": "^gpt-5\\.3-spark$", "canonical": "gpt-5.3-codex-spark" },
+    { "pattern": "^gpt-5\\.3-codex(?:-(?:low|high|xhigh))?-fast$", "canonical": "gpt-5.3-codex-fast" },
+    { "pattern": "^gpt-5\\.3-codex(?:-(?:low|high|xhigh))?$", "canonical": "gpt-5.3-codex" },
+    { "pattern": "^gpt-5\\.4-mini(?:-(?:none|low|medium|high|xhigh))?$", "canonical": "gpt-5.4-mini" },
+    { "pattern": "^gpt-5\\.4-nano(?:-(?:none|low|medium|high|xhigh))?$", "canonical": "gpt-5.4-nano" },
+    { "pattern": "^gpt-5\\.4-(?:low|medium|high|xhigh)-fast$", "canonical": "gpt-5.4-fast" },
+    { "pattern": "^gpt-5\\.4-(?:low|medium|high|xhigh)$", "canonical": "gpt-5.4" },
+    { "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?-fast$", "canonical": "gpt-5.5-fast" },
+    { "pattern": "^gpt-5\\.5(?:-(?:low|medium|high|xhigh|extra-high))?$", "canonical": "gpt-5.5" },
+    { "pattern": "^gpt-5\\.6-sol(?:-(?:none|low|medium|high|xhigh|max|ultra))?-fast$", "canonical": "gpt-5.6-sol-fast" },
+    { "pattern": "^gpt-5\\.6-sol(?:-(?:none|low|medium|high|xhigh|max|ultra))?$", "canonical": "gpt-5.6-sol" },
+    { "pattern": "^gpt-5\\.6-terra(?:-(?:none|low|medium|high|xhigh|max))?-fast$", "canonical": "gpt-5.6-terra-fast" },
+    { "pattern": "^gpt-5\\.6-terra(?:-(?:none|low|medium|high|xhigh|max))?$", "canonical": "gpt-5.6-terra" },
+    { "pattern": "^gpt-5\\.6-luna(?:-(?:none|low|medium|high|xhigh|max))?-fast$", "canonical": "gpt-5.6-luna-fast" },
+    { "pattern": "^gpt-5\\.6-luna(?:-(?:none|low|medium|high|xhigh|max))?$", "canonical": "gpt-5.6-luna" },
+    { "pattern": "^(?:gpt-)?daybreak-blue-latest$", "canonical": "gpt-5.6-sol" },
+    { "pattern": "^kimi-k2\\.5$", "canonical": "moonshot/kimi-k2.5" },
+    { "pattern": "^kimi-k2p5$", "canonical": "moonshot/kimi-k2.5" },
+    { "pattern": "^glm-5\\.2(?:-(?:high|max))?$", "canonical": "glm-5.2" },
+    { "pattern": "^[Pp]remium \\((?:[Gg][Pp][Tt]-5\\.3-[Cc]odex|[Cc]odex 5\\.3)\\)$", "canonical": "gpt-5.3-codex" },
+    { "pattern": "(?i)^Composer 2\\.5 Fast \\(Auto[^)]*\\)$", "canonical": "composer-2.5-fast" },
+    { "pattern": "(?i)^Composer 2\\.5 \\(Auto[^)]*\\)$", "canonical": "composer-2.5" },
+    { "pattern": "(?i)^Composer 2 Fast \\(Auto[^)]*\\)$", "canonical": "composer-2-fast" },
+    { "pattern": "(?i)^Composer 2 \\(Auto[^)]*\\)$", "canonical": "composer-2" },
+    { "pattern": "(?i)^(?:Cursor )?Grok 4\\.6 Fast \\(Auto[^)]*\\)$", "canonical": "grok-4.6-fast" },
+    { "pattern": "(?i)^(?:Cursor )?Grok 4\\.6 \\(Auto[^)]*\\)$", "canonical": "grok-4.6" },
+    { "pattern": "(?i)^(?:Cursor )?Grok 4\\.5 Fast \\(Auto[^)]*\\)$", "canonical": "grok-4.5-fast" },
+    { "pattern": "(?i)^(?:Cursor )?Grok 4\\.5 \\(Auto[^)]*\\)$", "canonical": "grok-4.5" },
+    { "pattern": "(?i)^(?:Claude )?Haiku 4\\.5 \\(Auto[^)]*\\)$", "canonical": "claude-haiku-4-5" },
+    { "pattern": "(?i)^(?:Claude )?Opus 4\\.8 \\(Auto[^)]*\\)$", "canonical": "claude-opus-4-8" },
+    { "pattern": "(?i)^(?:Claude )?Opus 5 \\(Auto[^)]*\\)$", "canonical": "claude-opus-5" },
+    { "pattern": "(?i)^(?:Claude )?Sonnet 5 \\(Auto[^)]*\\)$", "canonical": "claude-sonnet-5" },
+    { "pattern": "(?i)^(?:Claude )?Fable 5 \\(Auto[^)]*\\)$", "canonical": "claude-fable-5" },
+    { "pattern": "(?i)^GPT-5\\.5 \\(Auto[^)]*\\)$", "canonical": "gpt-5.5" },
+    { "pattern": "(?i)^GPT-5\\.6 Sol \\(Auto[^)]*\\)$", "canonical": "gpt-5.6-sol" },
+    { "pattern": "(?i)^GPT-5\\.6 Terra \\(Auto[^)]*\\)$", "canonical": "gpt-5.6-terra" },
+    { "pattern": "(?i)^GPT-5\\.6 Luna \\(Auto[^)]*\\)$", "canonical": "gpt-5.6-luna" },
+    { "pattern": "(?i)^Gemini 3\\.1 Pro \\(Auto[^)]*\\)$", "canonical": "gemini-3.1-pro-preview" },
+    { "pattern": "(?i)^GLM 5\\.2 \\(Auto[^)]*\\)$", "canonical": "glm-5.2" },
+    { "pattern": "(?i)^Kimi K3 \\(Auto[^)]*\\)$", "canonical": "kimi-k3" }
   ]
 }

--- a/crates/crossusage-core/src/codex_usage_scanner.rs
+++ b/crates/crossusage-core/src/codex_usage_scanner.rs
@@ -3,7 +3,7 @@
 use crate::claude_usage_scanner;
 use crate::codex_pricing::{self, CodexCostInput};
 use crate::log_usage_types::{
-    DailyUsageRow, LogScanStatus, ModelDayUsage, TokenBreakdown, cap_log_files_by_mtime,
+    DailyUsageRow, LogScanStatus, ModelDayUsage, cap_log_files_by_mtime,
     expand_tilde, host_query_response, local_day_key_from_offset, merge_daily_rows,
     since_local_midnight, warn_unreadable_usage_file,
 };
@@ -28,6 +28,8 @@ struct CachedFile {
 struct CodexEvent {
     timestamp: OffsetDateTime,
     model: String,
+    /// Dated Codex model used only to price `codex-auto-review` rows (#1085).
+    pricing_model: Option<String>,
     input: i32,
     cached: i32,
     output: i32,
@@ -505,10 +507,16 @@ fn parse_file(path: &Path) -> Vec<CodexEvent> {
         }
         let parsed_model = model_name_in_map(p).or_else(|| info.and_then(model_name_in_map));
         let model = resolve_model(parsed_model, &mut current_model);
+        let pricing_model = if model == AUTO_REVIEW_MODEL {
+            Some(auto_review_fallback(&event_day_key(&timestamp)))
+        } else {
+            None
+        };
         let cached = usage.cached.min(usage.input);
         events.push(CodexEvent {
             timestamp,
             model,
+            pricing_model,
             input: usage.input,
             cached,
             output: usage.output,
@@ -540,9 +548,6 @@ fn model_name_in_map(json: &serde_json::Map<String, Value>) -> Option<String> {
 fn resolve_model(parsed: Option<String>, current_model: &mut Option<String>) -> String {
     if let Some(parsed) = parsed {
         *current_model = Some(parsed.clone());
-        if parsed == "codex-auto-review" {
-            return "gpt-5.3-codex".to_string();
-        }
         return parsed;
     }
     current_model.clone().unwrap_or_else(|| {
@@ -552,13 +557,54 @@ fn resolve_model(parsed: Option<String>, current_model: &mut Option<String>) -> 
     })
 }
 
+const AUTO_REVIEW_MODEL: &str = "codex-auto-review";
+
+/// `codex-auto-review` release timeline (newest first). A line dated on/after a
+/// release prices as that Codex model; the usage slug stays `codex-auto-review`.
+const AUTO_REVIEW_FALLBACKS: &[(&str, &str)] = &[
+    ("2026-04-23", "gpt-5.5"),
+    ("2026-03-05", "gpt-5.4"),
+    ("2026-02-05", "gpt-5.3-codex"),
+    ("2025-12-11", "gpt-5.2-codex"),
+    ("2025-11-13", "gpt-5.1-codex"),
+    ("2025-09-15", "gpt-5-codex"),
+    ("2025-08-07", "gpt-5"),
+];
+
+fn event_day_key(ts: &OffsetDateTime) -> String {
+    format!(
+        "{:04}-{:02}-{:02}",
+        ts.year(),
+        u8::from(ts.month()),
+        ts.day()
+    )
+}
+
+fn auto_review_fallback(date: &str) -> String {
+    if date.len() != 10 || !date.as_bytes().iter().enumerate().all(|(i, b)| {
+        if i == 4 || i == 7 {
+            *b == b'-'
+        } else {
+            b.is_ascii_digit()
+        }
+    }) {
+        return "gpt-5".to_string();
+    }
+    AUTO_REVIEW_FALLBACKS
+        .iter()
+        .find(|(released, _)| date >= *released)
+        .map(|(_, model)| (*model).to_string())
+        .unwrap_or_else(|| "gpt-5".to_string())
+}
+
 fn dedup_events(events: Vec<CodexEvent>) -> Vec<CodexEvent> {
-    let mut seen: HashSet<(i128, String, i32, i32, i32, i32)> = HashSet::new();
+    let mut seen: HashSet<(i128, String, Option<String>, i32, i32, i32, i32)> = HashSet::new();
     let mut out = Vec::new();
     for e in events {
         let key = (
             e.timestamp.unix_timestamp_nanos(),
             e.model.clone(),
+            e.pricing_model.clone(),
             e.input,
             e.cached,
             e.output,
@@ -584,10 +630,11 @@ fn aggregate(events: &[CodexEvent], since: OffsetDateTime, pricing: &ModelPricin
             continue;
         }
         let day = local_day_key_from_offset(&event.timestamp);
+        let pricing_model = event.pricing_model.as_deref().unwrap_or(&event.model);
         let Some(cost) = codex_pricing::estimated_cost_dollars(
             pricing,
             &CodexCostInput {
-                model: &event.model,
+                model: pricing_model,
                 input: event.input,
                 cached: event.cached,
                 output: event.output,
@@ -727,5 +774,39 @@ mod tests {
         assert!(names.contains("b.jsonl"));
         assert_eq!(files.len(), 2, "archived duplicate of sessions/a.jsonl skipped");
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn auto_review_keeps_slug_and_uses_dated_pricing_model() {
+        let mut current = None;
+        assert_eq!(
+            resolve_model(Some("codex-auto-review".into()), &mut current),
+            "codex-auto-review"
+        );
+        assert_eq!(auto_review_fallback("2026-04-23"), "gpt-5.5");
+        assert_eq!(auto_review_fallback("2026-02-05"), "gpt-5.3-codex");
+        assert_eq!(auto_review_fallback("2025-08-01"), "gpt-5");
+        assert_eq!(auto_review_fallback("bogus"), "gpt-5");
+
+        let ts = OffsetDateTime::from_unix_timestamp(1_774_947_200).expect("ts");
+        let rows = aggregate(
+            &[CodexEvent {
+                timestamp: ts,
+                model: AUTO_REVIEW_MODEL.into(),
+                pricing_model: Some("gpt-5.5".into()),
+                input: 1000,
+                cached: 0,
+                output: 100,
+                reasoning: 0,
+                total: 1100,
+                is_fast: false,
+            }],
+            ts,
+            &ModelPricing::from_bundled(),
+        );
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].models.contains_key("codex-auto-review"));
+        assert!(!rows[0].models.contains_key("gpt-5.5"));
+        assert!(rows[0].total_cost.unwrap_or(0.0) > 0.0);
     }
 }

--- a/crates/crossusage-core/src/model_pricing.rs
+++ b/crates/crossusage-core/src/model_pricing.rs
@@ -1,10 +1,11 @@
 //! Bundled model pricing (supplement + LiteLLM compact snapshot).
-//! Ports upstream OpenUsage v0.7.3+ aliases; v0.7.4 #909 refreshes price lists hourly
-//! upstream via gh-pages. This fork ships the bundled supplement (`updated_at` in JSON)
+//! Ports upstream OpenUsage v0.7.3+ aliases; v0.7.8/0.7.9 add Kimi K3, Opus 5, Grok 4.6,
+//! Daybreak Blue, and Cursor Router prose labels. Upstream #909 refreshes price lists hourly
+//! via gh-pages. This fork ships the bundled supplement (`updated_at` in JSON)
 //! and does not fetch over the network — optional follow-up if live refresh is needed.
 
 use crate::log_usage_types::TokenBreakdown;
-use regex_lite::Regex;
+use regex_lite::{Regex, RegexBuilder};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -321,18 +322,30 @@ fn load_supplement(json: &str) -> PricingSupplement {
         .alias_rules
         .into_iter()
         .filter_map(|rule| {
-            Regex::new(&rule.pattern)
-                .ok()
-                .map(|pattern| AliasRule {
-                    pattern,
-                    canonical: rule.canonical,
-                })
+            compile_alias_pattern(&rule.pattern).map(|pattern| AliasRule {
+                pattern,
+                canonical: rule.canonical,
+            })
         })
         .collect();
     PricingSupplement {
         pricing,
         fast_multipliers: file.fast_multipliers,
         alias_rules,
+    }
+}
+
+/// Upstream Swift NSRegularExpression accepts `(?i)` inline flags. regex-lite does not;
+/// strip a leading `(?i)` and compile case-insensitively instead (Cursor Router labels).
+fn compile_alias_pattern(pattern: &str) -> Option<Regex> {
+    let (body, case_insensitive) = match pattern.strip_prefix("(?i)") {
+        Some(rest) => (rest, true),
+        None => (pattern, false),
+    };
+    if case_insensitive {
+        RegexBuilder::new(body).case_insensitive(true).build().ok()
+    } else {
+        Regex::new(body).ok()
     }
 }
 
@@ -414,9 +427,24 @@ mod tests {
         let grok = p.resolve("grok-4.5-fast-high").expect("grok fast high");
         let grok_fast = p.resolve("grok-4.5-fast").expect("grok fast");
         assert!((grok.input_per_million - grok_fast.input_per_million).abs() < 0.01);
+        assert!((grok_fast.output_per_million - 12.0).abs() < 0.01);
         assert!(p.can_price("cursor-grok-4.5-fast-xhigh"));
         assert!(p.can_price("kimi-k2.7-code"));
         assert!(p.can_price("kimi-k2p7"));
+    }
+
+    #[test]
+    fn v078_v079_pricing_aliases() {
+        let p = ModelPricing::from_bundled();
+        let k3 = p.resolve("kimi-k3").expect("kimi k3");
+        assert!((k3.input_per_million - 3.0).abs() < 0.01);
+        let grok46 = p.resolve("cursor-grok-4.6-fast-high").expect("grok 4.6");
+        assert!((grok46.input_per_million - 4.0).abs() < 0.01);
+        let opus5 = p.resolve("claude-opus-5").expect("opus 5");
+        assert!((opus5.input_per_million - 5.0).abs() < 0.01);
+        assert!(p.can_price("daybreak-blue-latest"));
+        let router = p.resolve("Opus 5 (Auto Balanced)").expect("cursor router");
+        assert!((router.input_per_million - 5.0).abs() < 0.01);
     }
 
     #[test]

--- a/docs/FORK-UPSTREAM.md
+++ b/docs/FORK-UPSTREAM.md
@@ -4,7 +4,7 @@ CrossUsage is the **Tauri Linux/Windows** line. Upstream **OpenUsage 0.7+** is a
 
 **UI diff target:** compare Modern layout work against **`upstream/swift`**, not `upstream/main`. Port spec: [OPENUSAGE-0.7-UI-SPEC.md](./OPENUSAGE-0.7-UI-SPEC.md).
 
-**Release trigger:** **1.2.0** → v0.7.0 Modern UI. **1.3.0** → v0.7.1 + i18n ([PORT-0.7.1.md](./PORT-0.7.1.md)). **1.3.1** → bundled v0.7.2 + v0.7.3 ([PORT-0.7.2-0.7.3.md](./PORT-0.7.2-0.7.3.md)). **1.3.2** → bundled v0.7.4 + v0.7.5 ([PORT-0.7.4-0.7.5.md](./PORT-0.7.4-0.7.5.md)). **1.3.3** → v0.7.6 ([PORT-0.7.6.md](./PORT-0.7.6.md)). **1.4.0** → fork-only features per [VERSIONING.md](./VERSIONING.md).
+**Release trigger:** **1.2.0** → v0.7.0 Modern UI. **1.3.0** → v0.7.1 + i18n ([PORT-0.7.1.md](./PORT-0.7.1.md)). **1.3.1** → bundled v0.7.2 + v0.7.3 ([PORT-0.7.2-0.7.3.md](./PORT-0.7.2-0.7.3.md)). **1.3.2** → bundled v0.7.4 + v0.7.5 ([PORT-0.7.4-0.7.5.md](./PORT-0.7.4-0.7.5.md)). **1.3.3** → v0.7.6 ([PORT-0.7.6.md](./PORT-0.7.6.md)). **1.4.0** → fork-only features per [VERSIONING.md](./VERSIONING.md). **1.4.1** → v0.7.8 + v0.7.9 ([PORT-0.7.8-0.7.9.md](./PORT-0.7.8-0.7.9.md); public v0.7.7 skipped upstream).
 
 ## What to port
 

--- a/docs/PORT-0.7.8-0.7.9.md
+++ b/docs/PORT-0.7.8-0.7.9.md
@@ -1,0 +1,66 @@
+# OpenUsage v0.7.8 + v0.7.9 port (CrossUsage 1.4.1)
+
+Upstream **v0.7.8** (2026-08-11) and **v0.7.9** (2026-08-13) are Swift-only. Robin **skipped a public v0.7.7** (`v0.7.6...v0.7.8`; only `v0.7.7-beta.1` exists). Port by rewriting applicable Swift into JS plugins + Rust scanners + React/Tauri.
+
+**Version:** [**1.4.1**](./VERSIONING.md) — upstream bundle = **PATCH**. Baseline: CrossUsage **1.4.0** (fork MINOR). Tags: `v0.7.8`, `v0.7.9`.
+
+**Strategy:** One patch bundling **all applicable 0.7.8 + 0.7.9** behavior. User asked to PR/merge + GitHub Release.
+
+## Status legend
+
+| Status | Meaning |
+|--------|---------|
+| **ship** | In **1.4.1** scope |
+| **skip** | macOS-only, upstream infra, or already in the fork |
+| **later** | Valid fork work; OK to defer |
+
+## Phase 1 — Pricing (**P0**)
+
+| Upstream | CrossUsage action | Status |
+|----------|-------------------|--------|
+| Price Kimi K3 + Cursor Router prose labels (#1087) | Bundled `pricing_supplement.json` + `(?i)` alias compile | **done** |
+| Claude Opus 5 (+ fast) (#1050) | Supplement rates + aliases | **done** |
+| Grok 4.6; Grok 4.5 Fast output $12 (#1101) | Supplement + aliases | **done** |
+| Daybreak Blue → `gpt-5.6-sol` (#1093) | Alias | **done** |
+| Newer of cached vs bundled supplement (#1089) | Fork does **not** fetch gh-pages; bundled-only | **skip** |
+
+## Phase 2 — Plugins / scanners
+
+| Upstream | CrossUsage action | Status |
+|----------|-------------------|--------|
+| Codex auto-review slug stays visible; dated fallback for cost only (#1085) | `codex_usage_scanner.rs` `pricing_model` | **done** |
+| OpenCode Go meters from `GET /zen/go/v1/usage` (#1097) | `plugins/opencode-go` — API when key present; SQLite leftover only without a key | **done** |
+| Cache parsed JSONL logs across launches (#1017) | Persistent scanner cache | **later** (in-process `FILE_CACHE` already; disk cache is a large Swift port) |
+
+## Phase 3 — Settings / UI
+
+| Upstream | CrossUsage action | Status |
+|----------|-------------------|--------|
+| Reduce Animations (#1019) | Settings toggle + `reduce-animations` class | **done** |
+| Reset All Settings with confirm (#1033) | Advanced row; restores UI prefs, not credentials / poll identity | **done** |
+
+## Skip
+
+| Upstream | Why |
+|----------|-----|
+| Account-first Phase 2 + 2b (#1030, #1031) | **Reverted** upstream before 0.7.8 (#1090) |
+| Account-first Phase 0 + 1 (#1026, #1027) | Fork already has multi-account + encrypted credentials |
+| PostHog iOS / Sparkle / `actions/stale` | macOS / upstream CI |
+| JSONL persistent scan cache (#1017) | **later** (see above) |
+| Pricing live fetch vs bundled (#1089) | No network pricing feed in fork |
+
+## Tests & docs
+
+| Item | Status |
+|------|--------|
+| `cargo test -p crossusage-core` pricing + auto-review | **done** (135 pass; 2 known ccusage subprocess fails in this env) |
+| `bun run test` settings + opencode-go | **done** |
+| `CHANGELOG.md` **1.4.1** cites **v0.7.8 + v0.7.9** | **done** |
+| `docs/providers/opencode-go.md` | **done** |
+
+## Release checklist (1.4.1)
+
+1. Branch: `feat/port-openusage-0.7.8-0.7.9` from `feat/linux-windows-native-support` — **done** (local)
+2. Bump **1.4.1** version files — **done**
+3. `bun run test` + `cargo test -p crossusage-core` + `bun run build` — **done** (no GitHub push)
+4. PR / merge / GitHub Release **v1.4.1** — in progress (user asked)

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -1,7 +1,13 @@
 # Breadcrumbs
 
+## 2026-08-18
+
+- 1.4.1 motion pass 6: removed **concentric grain rings** (the “100 circles”). Restored orbs. Click ripples still off.
+- 1.4.1 motion pass 4: still **no panel tilt/zoom**. Extra overlay FX: dual aurora, parallax grid, dust, slow scan, spark cursor. Reduce animations still kills all FX.
+
 ## 2026-08-13
 
+- Port OpenUsage **v0.7.8 + v0.7.9** → CrossUsage **1.4.1** on `feat/port-openusage-0.7.8-0.7.9` (not pushed). Public **v0.7.7** skipped upstream (`v0.7.6...v0.7.8`). Pricing supplement 2026-08-13; Codex auto-review slug; OpenCode Go official usage API; Reduce animations; Reset all settings. Tracker: [PORT-0.7.8-0.7.9.md](./PORT-0.7.8-0.7.9.md).
 - Live poll `aptabase-extra-2026-08`: `expiresAt` 2026-08-15T23:59:59Z + close date in body. `selectActivePoll` keeps expired/ended published polls on `/active` for results. `/active` cache 60s. Server-only — 1.4.0 clients already render `body` + `ended`.
 
 ## 2026-08-09

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -1,7 +1,14 @@
 # Choices
 
+## 2026-08-18
+
+- **Motion vs Reduce animations:** No live 3D/zoom on the whole panel. No concentric grain rings (looked like ~100 circles) and no click ripples. Orbs stay. Pointer drives spotlight/comet/grid. OS reduce-motion still hard-kills.
+
 ## 2026-08-13
 
+- **1.4.1 port scope:** OpenUsage **v0.7.8 + v0.7.9** as one PATCH. Skip public v0.7.7 (never shipped). Skip Account-first Phase 2/2b (reverted #1090), PostHog/Sparkle/stale, JSONL disk cache (#1017 later), live pricing fetch (#1089 — fork bundled-only).
+- **Reset all settings:** restore UI prefs only. Keep plugin order/disabled/credentials and poll `installId` / answers / dismissals. Polls enabled returns to default ON. Other locales fall back to English for new strings.
+- **OpenCode Go:** official `GET /zen/go/v1/usage` when a Go API key exists; SQLite leftover meters only without a key (matches #1097).
 - **Aptabase poll close:** Saturday **15 Aug 2026, 23:59 UTC** (`expiresAt`). Same sentence in `body`. After expiry, `/active` still returns the poll (`ended: true`) so a winner can show; set `active: false` to hide. Open poll preferred if several are published.
 
 ## 2026-08-09

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -1,62 +1,41 @@
 # OpenCode Go
 
-> Uses local OpenCode history from SQLite to track observed OpenCode Go spend on this machine.
+> Go plan meters come from OpenCode's official usage API when a local Go API key exists. Without a key, CrossUsage falls back to observed local SQLite spend.
 
 ## Overview
 
-- **Source of truth:** `~/.local/share/opencode/opencode.db`
-- **Auth discovery:** `~/.local/share/opencode/auth.json`
 - **Provider ID:** `opencode-go`
-- **Usage scope:** local observed assistant spend only
+- **Auth:** `~/.local/share/opencode/auth.json` (`opencode-go` entry `key`) or a Settings provider-account API key
+- **Account meters:** `GET https://opencode.ai/zen/go/v1/usage` (`Authorization: Bearer <key>`)
+- **Local fallback:** `~/.local/share/opencode/opencode.db` assistant `cost` rows (this machine only)
 
 ## Detection
 
-The plugin enables when either condition is true:
+The plugin enables when either:
 
-- `~/.local/share/opencode/auth.json` contains an `opencode-go` entry with a non-empty `key`
-- local OpenCode history already contains `opencode-go` assistant messages with numeric `cost`
+- auth has a non-empty Go key, or
+- local history already contains `opencode-go` assistant messages with numeric `cost`
 
-If neither signal exists, the plugin stays hidden.
+## Data source
 
-## Data Source
+**With a key:** Session / Weekly / Monthly are **account-wide percents** from `/zen/go/v1/usage` (same numbers as the OpenCode dashboard), plus ISO `resetsAt`. Local SQLite is not used for those bars.
 
-OpenUsage reads the local OpenCode SQLite database directly:
+**Without a key:** bars are observed local dollar spend vs published Go caps (`$12` / `$30` / `$60`), clamped at 100%.
 
-```sql
-SELECT
-  CAST(COALESCE(json_extract(data, '$.time.created'), time_created) AS INTEGER) AS createdMs,
-  CAST(json_extract(data, '$.cost') AS REAL) AS cost
-FROM message
-WHERE json_valid(data)
-  AND json_extract(data, '$.providerID') = 'opencode-go'
-  AND json_extract(data, '$.role') = 'assistant'
-  AND json_type(data, '$.cost') IN ('integer', 'real')
-```
+## API errors
 
-Only assistant messages with numeric `cost` count. Missing remote or other-device usage is not estimated.
+| HTTP | Meaning |
+|------|---------|
+| 401 | Key rejected — sign into OpenCode Go again |
+| 403 `EntitlementError` | No Go subscription on this key |
+| other / unreachable | Fail loudly (no silent $0) |
 
-## Limits
+## Window rules (local fallback only)
 
-OpenUsage uses the current published OpenCode Go plan limits from the official docs:
+- `5h`: rolling last 5 hours
+- `Weekly`: UTC Monday `00:00`
+- `Monthly`: earliest local Go usage as subscription-style anchor
 
-- `5h`: `$12`
-- `Weekly`: `$30`
-- `Monthly`: `$60`
+## Port
 
-Bars show observed local spend as a percentage of those fixed limits and clamp at `100%`.
-
-## Window Rules
-
-- `5h`: rolling last 5 hours from now
-- `Weekly`: UTC Monday `00:00` through the next UTC Monday `00:00`
-- `Monthly`: inferred subscription-style monthly window using the earliest local OpenCode Go usage timestamp as the anchor
-
-Monthly usage is inferred from local history, not read from OpenCode’s account API. OpenUsage reuses the earliest observed local OpenCode Go usage timestamp as the monthly anchor. If no local history exists yet, it falls back to UTC calendar month boundaries until the first Go usage is recorded.
-
-## Failure Behavior
-
-If auth or prior history already indicates OpenCode Go is in use, but SQLite becomes unreadable or malformed, the provider stays visible and shows a grey `Status: No usage data` badge instead of failing hard.
-
-## Future Compatibility
-
-The public provider identity stays `opencode-go`. If OpenCode later exposes account-truth usage by API key, OpenUsage can swap the backend without changing the provider ID or UI contract.
+OpenUsage **v0.7.9** (#1097). CrossUsage 1.4.1.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crossusage",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/opencode-go/plugin.js
+++ b/plugins/opencode-go/plugin.js
@@ -2,8 +2,10 @@
   const PROVIDER_ID = "opencode-go";
   const AUTH_PATH = "~/.local/share/opencode/auth.json";
   const DB_PATH = "~/.local/share/opencode/opencode.db";
+  const USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
   const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
   const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
   const LIMITS = {
     session: 12,
     weekly: 30,
@@ -264,51 +266,95 @@
     ];
   }
 
-  function buildUnreadableSourceLines(ctx, detail) {
-    return {
-      plan: "Go",
-      warning: detail,
-      lines: [
-        ctx.line.badge({
-          label: "Status",
-          text: "Usage database unreadable",
-          color: "#f59e0b",
+  function clampReportedPercent(value) {
+    const n = readNumber(value);
+    if (n === null) return null;
+    return Math.round(Math.max(0, Math.min(100, n)) * 10) / 10;
+  }
+
+  function fetchGoMeters(ctx, apiKey) {
+    let resp;
+    try {
+      resp = ctx.host.http.request({
+        method: "GET",
+        url: USAGE_URL,
+        headers: {
+          Authorization: "Bearer " + apiKey,
+          Accept: "application/json",
+        },
+        timeoutMs: 15000,
+      });
+    } catch (e) {
+      ctx.host.log.error("Go usage API unreachable: " + String(e));
+      throw "OpenCode Go usage API unreachable. Check your connection.";
+    }
+
+    const status = readNumber(resp && resp.status);
+    const bodyText = resp && typeof resp.bodyText === "string" ? resp.bodyText : "";
+    const parsed = ctx.util.tryParseJson(bodyText);
+    const errorType =
+      parsed && parsed.error && typeof parsed.error.type === "string"
+        ? parsed.error.type.trim()
+        : "";
+
+    if (status === 401) {
+      throw "OpenCode Go key was rejected. Log into OpenCode Go again.";
+    }
+    if (status === 403 && errorType === "EntitlementError") {
+      throw "No OpenCode Go subscription on this key.";
+    }
+    if (status === null || status < 200 || status >= 300) {
+      throw "OpenCode Go usage API failed (HTTP " + String(status) + ").";
+    }
+    if (!parsed || typeof parsed !== "object" || !parsed.usage || typeof parsed.usage !== "object") {
+      throw "OpenCode Go usage API returned an invalid response.";
+    }
+
+    const windows = [
+      { key: "rolling", label: "Session", periodMs: FIVE_HOURS_MS },
+      { key: "weekly", label: "Weekly", periodMs: WEEK_MS },
+      { key: "monthly", label: "Monthly", periodMs: MONTH_MS },
+    ];
+    const lines = [];
+    for (let i = 0; i < windows.length; i += 1) {
+      const spec = windows[i];
+      const raw = parsed.usage[spec.key];
+      if (!raw || typeof raw !== "object") {
+        throw "OpenCode Go usage API returned an invalid response.";
+      }
+      const percent = clampReportedPercent(raw.percent);
+      if (percent === null) {
+        throw "OpenCode Go usage API returned an invalid response.";
+      }
+      const resetsAt =
+        typeof raw.resetsAt === "string" && raw.resetsAt.trim() ? raw.resetsAt.trim() : null;
+      lines.push(
+        ctx.line.progress({
+          label: spec.label,
+          used: percent,
+          limit: 100,
+          format: { kind: "percent" },
+          resetsAt,
+          periodDurationMs: spec.periodMs,
         }),
-      ],
-    };
+      );
+    }
+    return lines;
   }
 
   function probe(ctx) {
     const authKey = loadAuthKey(ctx);
+    if (authKey) {
+      return { plan: "Go", lines: fetchGoMeters(ctx, authKey) };
+    }
+
     const history = hasHistory(ctx);
-    const detected = !!authKey || (history.ok && history.present);
-
-    if (!detected) {
+    if (!history.ok || !history.present) {
       throw "OpenCode Go not detected. Log in with OpenCode Go or use it locally first.";
-    }
-
-    // Auth present but SQLite unreadable — fail loudly (#969), not a silent empty badge.
-    if (authKey && !history.ok) {
-      ctx.host.log.warn("opencode sqlite unreadable while auth exists");
-      return buildUnreadableSourceLines(
-        ctx,
-        "Couldn't read OpenCode's usage database. Check file permissions or repair opencode.db.",
-      );
-    }
-
-    if (!history.ok) {
-      return { plan: "Go", lines: buildSoftEmptyLines(ctx) };
     }
 
     const rowsResult = loadHistory(ctx);
     if (!rowsResult.ok) {
-      if (authKey) {
-        ctx.host.log.warn("opencode sqlite history query failed while auth exists");
-        return buildUnreadableSourceLines(
-          ctx,
-          "Couldn't read OpenCode's usage database. Check file permissions or repair opencode.db.",
-        );
-      }
       return { plan: "Go", lines: buildSoftEmptyLines(ctx) };
     }
 

--- a/plugins/opencode-go/plugin.test.js
+++ b/plugins/opencode-go/plugin.test.js
@@ -57,6 +57,26 @@ function setHistoryQuery(ctx, rows, options = {}) {
   });
 }
 
+function setUsageApi(ctx, { status = 200, body } = {}) {
+  ctx.host.http.request.mockImplementation((opts) => {
+    expect(opts.method).toBe("GET");
+    expect(opts.url).toBe("https://opencode.ai/zen/go/v1/usage");
+    expect(opts.headers.Authorization).toBe("Bearer go-key");
+    return {
+      status,
+      bodyText: typeof body === "string" ? body : JSON.stringify(body),
+    };
+  });
+}
+
+const API_USAGE = {
+  usage: {
+    rolling: { percent: 12.5, resetsAt: "2026-03-06T17:00:00.000Z" },
+    weekly: { percent: 40, resetsAt: "2026-03-09T00:00:00.000Z" },
+    monthly: { percent: 8, resetsAt: "2026-04-01T00:00:00.000Z" },
+  },
+};
+
 describe("opencode-go plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin;
@@ -97,13 +117,10 @@ describe("opencode-go plugin", () => {
     );
   });
 
-  it("enables with auth only and returns zeroed bars", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-06T12:00:00.000Z"));
-
+  it("enables with auth only and uses the official usage API", async () => {
     const ctx = makeCtx();
     setAuth(ctx);
-    setHistoryQuery(ctx, []);
+    setUsageApi(ctx, { body: API_USAGE });
 
     const plugin = await loadPlugin();
     const result = plugin.probe(ctx);
@@ -114,10 +131,11 @@ describe("opencode-go plugin", () => {
       "Weekly",
       "Monthly",
     ]);
-    expect(result.lines.every((line) => line.used === 0)).toBe(true);
+    expect(result.lines[0].used).toBe(12.5);
+    expect(result.lines[1].used).toBe(40);
+    expect(result.lines[2].used).toBe(8);
     expect(result.lines[0].resetsAt).toBe("2026-03-06T17:00:00.000Z");
-    expect(result.lines[1].resetsAt).toBe("2026-03-09T00:00:00.000Z");
-    expect(result.lines[2].resetsAt).toBe("2026-04-01T00:00:00.000Z");
+    expect(ctx.host.sqlite.query).not.toHaveBeenCalled();
   });
 
   it("enables with history only when auth is absent", async () => {
@@ -224,36 +242,23 @@ describe("opencode-go plugin", () => {
     expect(result.lines[0].used).toBe(100);
   });
 
-  it("returns a loud warning when sqlite is unreadable but auth exists", async () => {
+  it("throws when the Go key is rejected", async () => {
     const ctx = makeCtx();
     setAuth(ctx);
-    ctx.host.sqlite.query.mockImplementation(() => {
-      throw new Error("disk I/O error");
-    });
+    setUsageApi(ctx, { status: 401, body: { error: { type: "AuthError" } } });
 
     const plugin = await loadPlugin();
-    const result = plugin.probe(ctx);
-    expect(result.plan).toBe("Go");
-    expect(result.warning).toContain("usage database");
-    expect(result.lines).toEqual([
-      {
-        type: "badge",
-        label: "Status",
-        text: "Usage database unreadable",
-        color: "#f59e0b",
-      },
-    ]);
+    expect(() => plugin.probe(ctx)).toThrow(
+      "OpenCode Go key was rejected. Log into OpenCode Go again.",
+    );
   });
 
-  it("returns a loud warning when sqlite returns malformed JSON and auth exists", async () => {
+  it("throws when the key has no Go subscription", async () => {
     const ctx = makeCtx();
     setAuth(ctx);
-    ctx.host.sqlite.query.mockReturnValue("not-json");
+    setUsageApi(ctx, { status: 403, body: { error: { type: "EntitlementError" } } });
 
     const plugin = await loadPlugin();
-    const result = plugin.probe(ctx);
-    expect(result.warning).toContain("usage database");
-    expect(result.lines[0].text).toBe("Usage database unreadable");
-    expect(result.lines[0].color).toBe("#f59e0b");
+    expect(() => plugin.probe(ctx)).toThrow("No OpenCode Go subscription on this key.");
   });
 });

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossusage"
-version = "1.4.0"
+version = "1.4.1"
 description = "CrossUsage — cross-platform fork of OpenUsage, an open source AI subscription limit tracker"
 authors = ["barramee kottanawadee <barramee25038@gmail.com>"]
 homepage = "https://github.com/barramee27/crossusage"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "crossusage",
   "mainBinaryName": "crossusage",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.barramee27.crossusage",
   "build": {
     "beforeDevCommand": "node scripts/tauri-before-dev.cjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useSettingsPluginActions } from "@/hooks/app/use-settings-plugin-action
 import { useSettingsPluginList } from "@/hooks/app/use-settings-plugin-list"
 import { useSettingsSystemActions } from "@/hooks/app/use-settings-system-actions"
 import { useSettingsTheme } from "@/hooks/app/use-settings-theme"
+import { useReduceAnimations } from "@/hooks/app/use-reduce-animations"
 import { useSettingsUIScale } from "@/hooks/app/use-settings-ui-scale"
 import { useTrayIcon } from "@/hooks/app/use-tray-icon"
 import { useProductPolls } from "@/hooks/app/use-product-polls"
@@ -233,6 +234,7 @@ function App() {
 
   useSettingsTheme(themeMode)
   useSettingsUIScale(uiScale)
+  useReduceAnimations()
   useProductPolls({ onboardingComplete })
 
   const {

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -181,6 +181,7 @@ export function AppContent({
 
   if (resolvedView === "home") {
     return (
+      <div key="home" className="motion-view">
       <OverviewPage
         plugins={displayPlugins}
         pluginSettings={pluginSettings}
@@ -192,15 +193,21 @@ export function AppContent({
         onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
         showAccountIdentity={showAccountIdentity}
       />
+      </div>
     )
   }
 
   if (resolvedView === "polls") {
-    return <PollsPage key={pollsVisitNonce} />
+    return (
+      <div key={`polls-${pollsVisitNonce}`} className="motion-view">
+        <PollsPage />
+      </div>
+    )
   }
 
   if (resolvedView === "settings") {
     return (
+      <div key="settings" className="motion-view">
       <SettingsPage
         plugins={settingsPlugins}
         onReorder={onReorder}
@@ -260,6 +267,7 @@ export function AppContent({
         cursorRequestsLineAvailable={cursorRequestsLineAvailable}
         presentation={uiLayout === "modern" ? "modern" : "classic"}
       />
+      </div>
     )
   }
 
@@ -268,6 +276,7 @@ export function AppContent({
     : /* v8 ignore next */ undefined
 
   return (
+    <div key={selectedPlugin?.meta.id ?? "detail"} className="motion-view">
     <ProviderDetailPage
       plugin={selectedPlugin}
       onRetry={handleRetry}
@@ -277,5 +286,6 @@ export function AppContent({
       onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
       showAccountIdentity={showAccountIdentity}
     />
+    </div>
   )
 }

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -18,6 +18,8 @@ import { useAppPreferencesStore } from "@/stores/app-preferences-store"
 import { useAppUiStore } from "@/stores/app-ui-store"
 import { useProductPollsBadge } from "@/hooks/app/use-product-polls"
 import { useProductPollsStore } from "@/stores/product-polls-store"
+import { useMotionPointer } from "@/hooks/app/use-motion-pointer"
+import { MotionField } from "@/components/motion-field"
 
 type AppShellProps = {
   onRefreshAll: () => void
@@ -57,8 +59,8 @@ export function AppShell({
   onOnboardingComplete,
   onOnboardingSkip,
 }: AppShellProps) {
-  const { themeMode } = useAppPreferencesStore(
-    useShallow((state) => ({ themeMode: state.themeMode }))
+  const { themeMode, reduceAnimations } = useAppPreferencesStore(
+    useShallow((state) => ({ themeMode: state.themeMode, reduceAnimations: state.reduceAnimations }))
   )
 
   const {
@@ -94,6 +96,7 @@ export function AppShell({
   useTrayRestartBridge(updateStatus, onUpdateInstall)
   const platform = usePlatform()
   const macPopoverChrome = isTauri() && platform === "macos"
+  const panelMotionRef = useMotionPointer(!reduceAnimations)
 
   const onViewChange = (view: Parameters<typeof setActiveView>[0]) => {
     if (view === "polls") bumpPollsVisit()
@@ -106,6 +109,7 @@ export function AppShell({
       <LiquidGlassFilter active={themeMode === "glass"} />
       {macPopoverChrome ? <div className="tray-arrow" aria-hidden="true" /> : null}
       <div
+        ref={panelMotionRef}
         className="app-panel-surface relative w-full overflow-hidden rounded-[18px] select-none flex flex-col"
         style={
           macPopoverChrome && maxPanelHeightPx
@@ -113,6 +117,7 @@ export function AppShell({
             : undefined
         }
       >
+        <MotionField />
         <div className="flex flex-1 min-h-0 flex-row">
           <SideNav
             activeView={activeView}

--- a/src/components/app/modern-shell.tsx
+++ b/src/components/app/modern-shell.tsx
@@ -42,6 +42,8 @@ import type { UILayout } from "@/lib/settings"
 import { useProductPollsBadge } from "@/hooks/app/use-product-polls"
 import { useProductPollsStore } from "@/stores/product-polls-store"
 import { PollsPage } from "@/pages/polls"
+import { useMotionPointer } from "@/hooks/app/use-motion-pointer"
+import { MotionField } from "@/components/motion-field"
 
 type ModernScreen = "dashboard" | "customize" | "polls" | "settings"
 
@@ -81,7 +83,7 @@ export function ModernShell({
   const pollsVisitNonce = useProductPollsStore((s) => s.pollsVisitNonce)
   useTrayRestartBridge(updateStatus, onUpdateInstall)
 
-  const { themeMode, displayMode, resetTimerDisplayMode, modernDensity, displayCurrency, exchangeRatesRevision, showTotalSpend } =
+  const { themeMode, displayMode, resetTimerDisplayMode, modernDensity, displayCurrency, exchangeRatesRevision, showTotalSpend, reduceAnimations } =
     useAppPreferencesStore(
     useShallow((s) => ({
       themeMode: s.themeMode,
@@ -91,6 +93,7 @@ export function ModernShell({
       displayCurrency: s.displayCurrency,
       exchangeRatesRevision: s.exchangeRatesRevision,
       showTotalSpend: s.showTotalSpend,
+      reduceAnimations: s.reduceAnimations,
     })),
   )
 
@@ -255,6 +258,7 @@ export function ModernShell({
       }),
     [displayPlugins, pluginSettings, preferWeeklyLimit, nowMs],
   )
+  const panelMotionRef = useMotionPointer(!reduceAnimations)
 
   return (
     <div
@@ -262,7 +266,11 @@ export function ModernShell({
       data-density={modernDensity}
     >
       <LiquidGlassFilter active={themeMode === "glass"} />
-      <div className="app-panel-surface relative w-full overflow-hidden rounded-[18px] select-none flex flex-col min-h-[320px]">
+      <div
+        ref={panelMotionRef}
+        className="app-panel-surface relative w-full overflow-hidden rounded-[18px] select-none flex flex-col min-h-[320px]"
+      >
+        <MotionField />
         <nav
           className="flex gap-1 px-3 pt-2 pb-1 border-b border-border/50"
           aria-label="Modern navigation"
@@ -280,7 +288,8 @@ export function ModernShell({
               type="button"
               size="sm"
               variant={screen === id ? "default" : "ghost"}
-              className="relative flex-1"
+              className={cn("relative flex-1 motion-tab")}
+              data-active={screen === id}
               onClick={() => {
                 if (id === "settings") setActiveView("settings")
                 else if (id === "polls") {
@@ -295,8 +304,8 @@ export function ModernShell({
                 <span
                   className={
                     screen === id
-                      ? "absolute top-1 right-1 size-1.5 rounded-full bg-primary-foreground"
-                      : "absolute top-1 right-1 size-1.5 rounded-full bg-primary"
+                      ? "absolute top-1 right-1 size-1.5 rounded-full bg-primary-foreground motion-ping"
+                      : "absolute top-1 right-1 size-1.5 rounded-full bg-primary motion-ping"
                   }
                   aria-hidden
                 />
@@ -320,7 +329,7 @@ export function ModernShell({
             )}
           >
             {screen === "dashboard" ? (
-              <div className="space-y-2 pb-2">
+              <div key="dashboard" className="motion-view space-y-2 pb-2 motion-stagger">
                 <UsageInsightsBanner
                   insights={insights}
                   historyTightest={historyInsights?.tightest}
@@ -349,6 +358,7 @@ export function ModernShell({
             ) : null}
 
             {screen === "customize" ? (
+              <div key="customize" className="motion-view">
               <CustomizeView
                 descriptors={descriptors}
                 providerOrder={providerOrder}
@@ -370,11 +380,17 @@ export function ModernShell({
                 onMetricReorder={layout.setMetricOrder}
                 compact={compact}
               />
+              </div>
             ) : null}
 
-            {screen === "polls" ? <PollsPage key={pollsVisitNonce} /> : null}
+            {screen === "polls" ? (
+              <div key={`polls-${pollsVisitNonce}`} className="motion-view">
+                <PollsPage />
+              </div>
+            ) : null}
 
             {screen === "settings" ? (
+              <div key="settings" className="motion-view">
               <AppContent
                 {...appContentProps}
                 displayPlugins={displayPlugins}
@@ -382,6 +398,7 @@ export function ModernShell({
                 selectedPlugin={null}
                 viewOverride="settings"
               />
+              </div>
             ) : null}
           </div>
 

--- a/src/components/modern/total-spend-card.tsx
+++ b/src/components/modern/total-spend-card.tsx
@@ -81,7 +81,7 @@ export function TotalSpendCard({ providers, outputs, compact, className }: Total
   const info = `Only includes ${capable.map((p) => p.displayName).join(", ")}.`
 
   return (
-    <section className={cn("space-y-1.5", className)}>
+    <section className={cn("space-y-1.5 motion-card", className)}>
       <header className="flex items-center gap-1.5 px-1">
         <div className="relative">
           <Button

--- a/src/components/modern/widget-grouped-list.tsx
+++ b/src/components/modern/widget-grouped-list.tsx
@@ -31,13 +31,14 @@ export function WidgetGroupedList({ groups, compact, className, onRefreshPlugin 
   }
 
   return (
-    <div className={cn("space-y-2", className)}>
-      {groups.map((group) => (
+    <div className={cn("space-y-2 motion-stagger", className)}>
+      {groups.map((group, index) => (
         <ProviderCard
           key={group.pluginId}
           group={group}
           compact={compact}
           onRefreshPlugin={onRefreshPlugin}
+          index={index}
         />
       ))}
     </div>
@@ -48,10 +49,12 @@ function ProviderCard({
   group,
   compact,
   onRefreshPlugin,
+  index = 0,
 }: {
   group: ProviderWidgetGroup
   compact?: boolean
   onRefreshPlugin?: (pluginId: string) => void
+  index?: number
 }) {
   const bounded = group.metrics.filter((m) => m.bounded && m.kind === "progress")
   const charts = group.metrics.filter((m) => m.kind === "barChart")
@@ -59,8 +62,11 @@ function ProviderCard({
 
   return (
     <section
-      className="rounded-lg border bg-card/80 overflow-hidden"
-      style={group.brandColor ? { borderColor: `${group.brandColor}33` } : undefined}
+      className="rounded-lg border bg-card/80 overflow-hidden motion-card"
+      style={{
+        ["--i" as string]: index,
+        ...(group.brandColor ? { borderColor: `${group.brandColor}33` } : {}),
+      }}
     >
       <header
         className={cn(
@@ -76,7 +82,7 @@ function ProviderCard({
             style={group.brandColor ? { backgroundColor: group.brandColor } : undefined}
           />
         )}
-        <h3 className={cn("font-semibold truncate", compact ? "text-sm" : "text-base")}>
+        <h3 className={cn("font-semibold truncate motion-title", compact ? "text-sm" : "text-base")}>
           {group.name}
         </h3>
       </header>

--- a/src/components/modern/widget-row.tsx
+++ b/src/components/modern/widget-row.tsx
@@ -8,6 +8,7 @@ import type { PaceStatus } from "@/lib/pace-status"
 import { getPaceStatusText } from "@/lib/pace-tooltip"
 import { formatMoney } from "@/lib/locale-format"
 import { cn } from "@/lib/utils"
+import { MotionNumber } from "@/components/motion-number"
 
 const PACE_DOT: Record<PaceStatus, string> = {
   ahead: "bg-green-500",
@@ -46,7 +47,7 @@ function PaceDot({ data }: { data: WidgetData }) {
         render={(props) => (
           <span
             {...props}
-            className={cn("inline-block w-1.5 h-1.5 rounded-full shrink-0", !dotColor && PACE_DOT[status])}
+            className={cn("inline-block w-1.5 h-1.5 rounded-full shrink-0 motion-dot", !dotColor && PACE_DOT[status])}
             style={dotColor ? { backgroundColor: dotColor } : undefined}
             aria-label={data.isLimitReached ? "Limit reached" : getPaceStatusText(status)}
           />
@@ -211,16 +212,23 @@ export function WidgetRow({ data, compact, className, onRefreshPlugin }: WidgetR
       <div className={cn("flex items-center gap-1.5 mb-1", compact ? "text-xs" : "text-sm")}>
         <PaceDot data={data} />
         <span className="font-medium truncate flex-1">{data.label}</span>
-        <span className="tabular-nums shrink-0">{data.textValue}</span>
+        <span className="tabular-nums shrink-0">
+          {data.textValue ? <MotionNumber value={data.textValue} className="motion-number" /> : null}
+        </span>
       </div>
-      <div className={cn("rounded-full bg-muted overflow-hidden", compact ? "h-1" : "h-1.5")}>
+      <div className={cn("relative rounded-full bg-muted overflow-hidden", compact ? "h-1" : "h-1.5")}>
         <div
-          className={cn("h-full rounded-full transition-all", !fillColor && fillClass)}
+          className={cn(
+            "h-full rounded-full motion-bar-fill",
+            !fillColor && fillClass,
+            fraction >= 0.85 && "motion-bar-hot",
+          )}
           style={{
             width: `${Math.round(fraction * 100)}%`,
             ...(fillColor ? { backgroundColor: fillColor } : {}),
           }}
         />
+        {fraction >= 0.85 ? <span className="motion-sparks" aria-hidden="true" /> : null}
       </div>
       {data.textSecondary ? (
         <p className={cn("text-muted-foreground mt-0.5", compact ? "text-[10px]" : "text-xs")}>

--- a/src/components/motion-field.test.tsx
+++ b/src/components/motion-field.test.tsx
@@ -1,0 +1,51 @@
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { MotionField, fireMotionShock } from "@/components/motion-field"
+import { useAppPreferencesStore } from "@/stores/app-preferences-store"
+
+describe("MotionField", () => {
+  afterEach(() => {
+    useAppPreferencesStore.getState().resetState()
+    vi.useRealTimers()
+  })
+
+  it("renders aurora and orbs without grain rings or click ripples", () => {
+    render(
+      <div className="app-panel-surface">
+        <MotionField />
+      </div>,
+    )
+    expect(document.querySelectorAll(".motion-aurora").length).toBe(2)
+    expect(document.querySelector(".motion-scan")).toBeTruthy()
+    expect(document.querySelector(".motion-grid")).toBeTruthy()
+    expect(document.querySelector(".motion-dust")).toBeTruthy()
+    expect(document.querySelector(".motion-cursor")).toBeTruthy()
+    expect(document.querySelectorAll(".motion-orb").length).toBe(12)
+    expect(document.querySelector(".motion-grain")).toBeNull()
+    expect(document.querySelector(".motion-ripple")).toBeNull()
+  })
+
+  it("hides when reduce animations is on", () => {
+    useAppPreferencesStore.getState().setReduceAnimations(true)
+    render(<MotionField />)
+    expect(document.querySelector(".motion-field")).toBeNull()
+  })
+
+  it("spawns a shock ring on refresh burst", () => {
+    vi.useFakeTimers()
+    render(
+      <div className="app-panel-surface">
+        <MotionField />
+      </div>,
+    )
+    act(() => {
+      fireMotionShock()
+    })
+    expect(document.querySelector(".motion-shock-ring")).toBeTruthy()
+    act(() => {
+      vi.advanceTimersByTime(800)
+    })
+    expect(document.querySelector(".motion-shock-ring")).toBeNull()
+    expect(screen.queryByRole("img")).toBeNull()
+  })
+})

--- a/src/components/motion-field.tsx
+++ b/src/components/motion-field.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react"
+import { useAppPreferencesStore } from "@/stores/app-preferences-store"
+
+const ORBS = [
+  { x: "8%", y: "18%", s: "56px", t: "7.2s", d: "0s" },
+  { x: "78%", y: "12%", s: "38px", t: "9.1s", d: "0.4s" },
+  { x: "52%", y: "72%", s: "72px", t: "11s", d: "0.8s" },
+  { x: "18%", y: "64%", s: "28px", t: "6.4s", d: "1.1s" },
+  { x: "88%", y: "48%", s: "44px", t: "8.3s", d: "0.2s" },
+  { x: "40%", y: "28%", s: "22px", t: "5.5s", d: "1.6s" },
+  { x: "64%", y: "82%", s: "34px", t: "10s", d: "0.6s" },
+  { x: "6%", y: "88%", s: "48px", t: "7.8s", d: "1.3s" },
+  { x: "30%", y: "8%", s: "26px", t: "6.1s", d: "0.9s" },
+  { x: "92%", y: "78%", s: "40px", t: "8.8s", d: "1.8s" },
+  { x: "14%", y: "42%", s: "18px", t: "4.9s", d: "0.3s" },
+  { x: "70%", y: "36%", s: "52px", t: "9.6s", d: "1.4s" },
+] as const
+
+export function MotionField() {
+  const reduce = useAppPreferencesStore((s) => s.reduceAnimations)
+  const [shock, setShock] = useState(false)
+
+  useEffect(() => {
+    const onShock = () => {
+      setShock(true)
+      window.setTimeout(() => setShock(false), 750)
+    }
+    window.addEventListener("crossusage:motion-shock", onShock)
+    return () => window.removeEventListener("crossusage:motion-shock", onShock)
+  }, [])
+
+  if (reduce) return null
+
+  return (
+    <div className="motion-field" aria-hidden="true">
+      <div className="motion-aurora" />
+      <div className="motion-aurora motion-aurora-alt" />
+      <div className="motion-grid" />
+      <div className="motion-dust" />
+      <div className="motion-edge" />
+      <div className="motion-scan" />
+      <div className="motion-scan motion-scan-slow" />
+      <span className="motion-cursor" />
+      <span className="motion-cursor-lag" />
+      <span className="motion-cursor motion-cursor-spark" />
+      {ORBS.map((orb, i) => (
+        <span
+          key={i}
+          className="motion-orb"
+          style={{
+            ["--orb-x" as string]: orb.x,
+            ["--orb-y" as string]: orb.y,
+            ["--orb-s" as string]: orb.s,
+            ["--orb-t" as string]: orb.t,
+            ["--orb-d" as string]: orb.d,
+          }}
+        />
+      ))}
+      {shock ? (
+        <>
+          <span className="motion-shock-ring" />
+          <span className="motion-shock-ring motion-shock-late" />
+          <span className="motion-shock-ring motion-shock-later" />
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export function fireMotionShock() {
+  window.dispatchEvent(new Event("crossusage:motion-shock"))
+}

--- a/src/components/motion-number.test.ts
+++ b/src/components/motion-number.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { splitMetricText } from "@/components/motion-number"
+
+describe("splitMetricText", () => {
+  it("splits percents and money", () => {
+    expect(splitMetricText("12.5%")).toEqual({
+      prefix: "",
+      n: 12.5,
+      decimals: 1,
+      suffix: "%",
+    })
+    expect(splitMetricText("$3.20")).toEqual({
+      prefix: "$",
+      n: 3.2,
+      decimals: 2,
+      suffix: "",
+    })
+  })
+
+  it("returns null when there is no number", () => {
+    expect(splitMetricText("No usage data")).toBeNull()
+  })
+})

--- a/src/components/motion-number.tsx
+++ b/src/components/motion-number.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from "react"
+import { useAppPreferencesStore } from "@/stores/app-preferences-store"
+
+const METRIC_RE = /^(\D*?)(-?\d+(?:[.,]\d+)?)(\D*)$/
+
+export function splitMetricText(text: string) {
+  const match = text.trim().match(METRIC_RE)
+  if (!match) return null
+  const raw = match[2].replace(",", ".")
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return null
+  const decimals = raw.includes(".") ? (raw.split(".")[1]?.length ?? 0) : 0
+  return { prefix: match[1], n, decimals, suffix: match[3] }
+}
+
+function formatPart(n: number, decimals: number) {
+  if (decimals > 0) return n.toFixed(Math.min(3, decimals))
+  return String(Math.round(n))
+}
+
+export function useAnimatedMetricText(text: string, enabled: boolean) {
+  const [shown, setShown] = useState(text)
+  const fromRef = useRef(splitMetricText(text)?.n ?? 0)
+
+  useEffect(() => {
+    const parsed = splitMetricText(text)
+    if (!enabled || !parsed) {
+      setShown(text)
+      if (parsed) fromRef.current = parsed.n
+      return
+    }
+    const from = fromRef.current
+    const to = parsed.n
+    fromRef.current = to
+    if (from === to) {
+      setShown(text)
+      return
+    }
+    const started = performance.now()
+    const duration = 700
+    let frame = 0
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - started) / duration)
+      const eased = 1 - (1 - t) ** 3
+      const n = from + (to - from) * eased
+      setShown(`${parsed.prefix}${formatPart(n, parsed.decimals)}${parsed.suffix}`)
+      if (t < 1) frame = requestAnimationFrame(tick)
+    }
+    frame = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frame)
+  }, [enabled, text])
+
+  return shown
+}
+
+export function MotionNumber({
+  value,
+  className,
+}: {
+  value: string
+  className?: string
+}) {
+  const reduce = useAppPreferencesStore((s) => s.reduceAnimations)
+  const shown = useAnimatedMetricText(value, !reduce)
+  return (
+    <span className={className} data-motion-number={splitMetricText(value) ? "1" : undefined}>
+      {shown}
+    </span>
+  )
+}

--- a/src/components/panel-footer.tsx
+++ b/src/components/panel-footer.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { AboutDialog } from "@/components/about-dialog";
+import { fireMotionShock } from "@/components/motion-field";
 import type { UpdateStatus } from "@/hooks/use-app-update";
 import { useNowTicker } from "@/hooks/use-now-ticker";
 
@@ -127,9 +128,10 @@ export function PanelFooter({
             type="button"
             onClick={(event) => {
               event.currentTarget.blur()
+              fireMotionShock()
               onRefreshAll()
             }}
-            className="text-xs text-muted-foreground tabular-nums hover:text-foreground transition-colors cursor-pointer"
+            className="text-xs text-muted-foreground tabular-nums hover:text-foreground transition-colors cursor-pointer motion-tick"
             title="Refresh now"
           >
             {countdownLabel}

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -21,6 +21,7 @@ import { buildPaceDetailText, formatDeficitText, formatRunsOutText, getPaceStatu
 import { formatResetAbsoluteLabel, formatResetRelativeLabel, formatResetTooltipText } from "@/lib/reset-tooltip"
 import { formatMoney } from "@/lib/locale-format"
 import { useAppPreferencesStore } from "@/stores/app-preferences-store"
+import { MotionNumber } from "@/components/motion-number"
 
 interface ProviderCardProps {
   name: string
@@ -73,7 +74,7 @@ function PaceIndicator({
         render={(props) => (
           <span
             {...props}
-            className={`inline-block w-2 h-2 rounded-full ${colorClass}`}
+            className={`inline-block w-2 h-2 rounded-full motion-dot ${colorClass}`}
             aria-label={isLimitReached ? "Limit reached" : statusText}
           />
         )}
@@ -254,7 +255,7 @@ export function ProviderCard({
         <div className="mb-2 flex min-w-0 items-center gap-2">
           <div className="relative flex min-w-0 flex-1 items-center">
             <h2
-              className="min-w-0 truncate text-lg font-semibold"
+              className="min-w-0 truncate text-lg font-semibold motion-title"
               style={{ transform: "translateZ(0)" }}
             >
               {name}
@@ -268,7 +269,7 @@ export function ProviderCard({
                   style={{ transform: "translateZ(0)", backfaceVisibility: "hidden" }}
                   tabIndex={-1}
                 >
-                  <RefreshCw className="h-3 w-3 animate-spin" />
+                  <RefreshCw className="h-3 w-3 motion-spin-boost animate-spin" />
                 </Button>
               ) : inCooldown ? (
                 <Tooltip>
@@ -777,7 +778,7 @@ function MetricLineRenderer({
         />
         <div className="flex justify-between items-center mt-1.5">
           <span className="text-xs text-muted-foreground tabular-nums">
-            {primaryText}
+            <MotionNumber value={primaryText} className="motion-number" />
           </span>
           {secondaryText && (
             resetTooltipText ? (

--- a/src/components/side-nav.tsx
+++ b/src/components/side-nav.tsx
@@ -70,17 +70,18 @@ function NavButton({
       onContextMenu={onContextMenu}
       aria-label={ariaLabel}
       className={cn(
-        "relative flex items-center justify-center w-[calc(100%-1px)] p-2 transition-colors",
+        "relative flex items-center justify-center w-[calc(100%-1px)] p-2 transition-colors motion-nav-btn",
         "hover:bg-accent",
         isActive
           ? "text-foreground before:absolute before:left-0 before:top-1.5 before:bottom-1.5 before:w-0.5 before:bg-primary dark:before:bg-page-accent before:rounded-full"
           : "text-muted-foreground"
       )}
+      data-active={isActive}
     >
       {children}
       {badge ? (
         <span
-          className="absolute top-1.5 right-1.5 size-2 rounded-full bg-primary"
+          className="absolute top-1.5 right-1.5 size-2 rounded-full bg-primary motion-ping"
           aria-hidden
         />
       ) : null}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none motion-press",
   {
     variants: {
       variant: {

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -17,8 +17,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         data-slot="checkbox-indicator"
         className="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
       >
-        <CheckIcon
-        />
+        <CheckIcon className="motion-press" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -46,7 +46,10 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         {...props}
       >
         <div
-          className="h-full transition-all bg-primary"
+          className={cn(
+            "h-full bg-primary motion-bar-fill",
+            clamped >= 85 && "motion-bar-hot",
+          )}
           style={{ width: `${clamped}%`, ...indicatorStyle }}
         />
         {showMarker && (
@@ -66,6 +69,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
             <div className="h-full w-full animate-shimmer bg-gradient-to-r from-transparent via-white/20 to-transparent" />
           </div>
         )}
+        {clamped >= 85 ? <span className="motion-sparks" aria-hidden="true" /> : null}
       </div>
     )
   }

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -110,6 +110,15 @@ describe("ui components", () => {
     expect(container.querySelector('[data-slot="progress-refreshing"]')).toBeNull()
   })
 
+  it("marks high usage bars as hot for motion", () => {
+    const { container, rerender } = render(<Progress value={90} />)
+    expect(container.querySelector(".motion-bar-hot")).toBeTruthy()
+    expect(container.querySelector(".motion-sparks")).toBeTruthy()
+    rerender(<Progress value={40} />)
+    expect(container.querySelector(".motion-bar-hot")).toBeNull()
+    expect(container.querySelector(".motion-sparks")).toBeNull()
+  })
+
   it("renders separator orientations", () => {
     const { rerender } = render(<Separator />)
     expect(screen.getByRole("separator")).toBeInTheDocument()

--- a/src/hooks/app/use-motion-pointer.test.tsx
+++ b/src/hooks/app/use-motion-pointer.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { useMotionPointer } from "@/hooks/app/use-motion-pointer"
+
+function Probe({ enabled }: { enabled: boolean }) {
+  const ref = useMotionPointer(enabled)
+  return <div data-testid="host" ref={ref} />
+}
+
+describe("useMotionPointer", () => {
+  it("writes --mx/--my only (no panel tilt/scale) and resets when disabled", () => {
+    const { getByTestId, rerender } = render(<Probe enabled />)
+    const host = getByTestId("host")
+    host.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 100, height: 100, right: 100, bottom: 100 }) as DOMRect
+
+    fireEvent.pointerMove(host, { clientX: 80, clientY: 20 })
+    expect(host.style.getPropertyValue("--mx")).toBe("0.800")
+    expect(host.style.getPropertyValue("--my")).toBe("0.200")
+    expect(host.style.getPropertyValue("--tilt-y")).toBe("")
+    expect(host.style.getPropertyValue("--panel-scale")).toBe("")
+
+    rerender(<Probe enabled={false} />)
+    expect(host.style.getPropertyValue("--mx")).toBe("0.5")
+    expect(host.style.getPropertyValue("--tilt-x")).toBe("")
+  })
+})

--- a/src/hooks/app/use-motion-pointer.ts
+++ b/src/hooks/app/use-motion-pointer.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from "react"
+
+/** Cursor spotlight via --mx/--my. No panel tilt/scale — that warped the window. */
+export function useMotionPointer(enabled: boolean) {
+  const [node, setNode] = useState<HTMLDivElement | null>(null)
+  const ref = useCallback((el: HTMLDivElement | null) => {
+    setNode(el)
+  }, [])
+
+  useEffect(() => {
+    const el = node
+    if (!el) return
+
+    const reset = () => {
+      el.style.setProperty("--mx", "0.5")
+      el.style.setProperty("--my", "0.5")
+      el.style.removeProperty("--tilt-x")
+      el.style.removeProperty("--tilt-y")
+      el.style.removeProperty("--panel-scale")
+    }
+
+    if (!enabled) {
+      reset()
+      return
+    }
+
+    const onMove = (event: PointerEvent) => {
+      const box = el.getBoundingClientRect()
+      if (box.width <= 0 || box.height <= 0) return
+      const x = Math.min(1, Math.max(0, (event.clientX - box.left) / box.width))
+      const y = Math.min(1, Math.max(0, (event.clientY - box.top) / box.height))
+      el.style.setProperty("--mx", x.toFixed(3))
+      el.style.setProperty("--my", y.toFixed(3))
+    }
+
+    el.addEventListener("pointermove", onMove)
+    el.addEventListener("pointerleave", reset)
+    reset()
+    return () => {
+      el.removeEventListener("pointermove", onMove)
+      el.removeEventListener("pointerleave", reset)
+      reset()
+    }
+  }, [enabled, node])
+
+  return ref
+}

--- a/src/hooks/app/use-reduce-animations.ts
+++ b/src/hooks/app/use-reduce-animations.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react"
+import {
+  DEFAULT_REDUCE_ANIMATIONS,
+  loadReduceAnimations,
+} from "@/lib/settings"
+import { useAppPreferencesStore } from "@/stores/app-preferences-store"
+
+export function useReduceAnimations() {
+  const reduceAnimations = useAppPreferencesStore((s) => s.reduceAnimations)
+  const setReduceAnimations = useAppPreferencesStore((s) => s.setReduceAnimations)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadReduceAnimations()
+      .then((value) => {
+        if (!cancelled) setReduceAnimations(value)
+      })
+      .catch((error) => {
+        console.error("Failed to load reduce animations:", error)
+        if (!cancelled) setReduceAnimations(DEFAULT_REDUCE_ANIMATIONS)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [setReduceAnimations])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("reduce-animations", reduceAnimations)
+  }, [reduceAnimations])
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -148,6 +148,17 @@
       "title": "Interface scale",
       "description": "Text and spacing density in the main window"
     },
+    "reduceAnimations": {
+      "title": "Reduce animations",
+      "description": "Nuke every panel effect: aurora, orbs, 3D tilt, card float, bar sparks, click ripples, counting meters. Same idea as system reduce-motion.",
+      "checkbox": "Reduce animations"
+    },
+    "resetAll": {
+      "title": "Reset all settings",
+      "description": "Restore appearance, alerts, layout, shortcut, and tray prefs to defaults. Does not delete provider credentials or poll votes.",
+      "button": "Reset all settings",
+      "confirm": "Reset all settings to defaults? Provider accounts and poll answers stay."
+    },
     "startOnLogin": {
       "title": "Start on Login",
       "description": "Launch when you sign in"

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "./motion.css";
+@import "./motion-fx.css";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -679,3 +681,4 @@ html.tauri-popover body {
     opacity: 0.35;
   }
 }
+

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MENUBAR_ICON_STYLE,
   DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT,
   DEFAULT_PLUGIN_SETTINGS,
+  DEFAULT_REDUCE_ANIMATIONS,
   DEFAULT_RESET_TIMER_DISPLAY_MODE,
   DEFAULT_SHOW_ACCOUNT_IDENTITY,
   DEFAULT_START_ON_LOGIN,
@@ -44,7 +45,12 @@ import {
   loadUsageAlertThreshold,
   migrateLegacyTraySettings,
   loadThemeMode,
+  loadReduceAnimations,
+  loadProductPollsAnswered,
+  loadProductPollsEnabled,
+  loadProductPollsInstallId,
   normalizePluginSettings,
+  resetAllUserPreferences,
   resolveOnboardingComplete,
   saveAutoUpdateInterval,
   saveDisplayMode,
@@ -52,6 +58,10 @@ import {
   saveMenubarIconStyle,
   savePreferMenubarWeeklyLimit,
   savePluginSettings,
+  saveProductPollsAnswered,
+  saveProductPollsEnabled,
+  saveProductPollsInstallId,
+  saveReduceAnimations,
   saveResetTimerDisplayMode,
   saveShowAccountIdentity,
   saveStartOnLogin,
@@ -734,6 +744,43 @@ describe("settings", () => {
     it("returns true when stored version matches app version", async () => {
       storeState.set("dualUiOnboardingVersion", "1.1.0")
       await expect(resolveOnboardingComplete(pluginSettings, "1.1.0")).resolves.toBe(true)
+    })
+  })
+
+  describe("loadReduceAnimations / saveReduceAnimations", () => {
+    it("loads default when missing", async () => {
+      await expect(loadReduceAnimations()).resolves.toBe(DEFAULT_REDUCE_ANIMATIONS)
+    })
+
+    it("round-trips", async () => {
+      await saveReduceAnimations(true)
+      await expect(loadReduceAnimations()).resolves.toBe(true)
+    })
+  })
+
+  describe("resetAllUserPreferences", () => {
+    it("restores UI prefs and keeps plugins plus poll identity", async () => {
+      const plugins = {
+        order: ["cursor"],
+        disabled: ["mock"],
+        trayLines: { cursor: ["Requests"] },
+        providerInstances: {},
+      }
+      await savePluginSettings(plugins)
+      await saveThemeMode("dark")
+      await saveReduceAnimations(true)
+      await saveProductPollsEnabled(false)
+      await saveProductPollsInstallId("install-keep")
+      await saveProductPollsAnswered({ "poll-1": "opt-a" })
+
+      await resetAllUserPreferences()
+
+      await expect(loadThemeMode()).resolves.toBe(DEFAULT_THEME_MODE)
+      await expect(loadReduceAnimations()).resolves.toBe(DEFAULT_REDUCE_ANIMATIONS)
+      await expect(loadProductPollsEnabled()).resolves.toBe(true)
+      await expect(loadPluginSettings()).resolves.toEqual(plugins)
+      await expect(loadProductPollsInstallId()).resolves.toBe("install-keep")
+      await expect(loadProductPollsAnswered()).resolves.toEqual({ "poll-1": "opt-a" })
     })
   })
 })

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,6 +1,6 @@
 import { LazyStore } from "@tauri-apps/plugin-store";
 import type { PluginMeta, ProbeTarget } from "@/lib/plugin-types";
-import { normalizeModernLayout, type ModernLayoutState } from "@/lib/modern-layout";
+import { normalizeModernLayout, EMPTY_MODERN_LAYOUT, type ModernLayoutState } from "@/lib/modern-layout";
 import { migrateAntigravityLineLabel } from "@/lib/antigravity-label-migration";
 import {
   DEFAULT_APP_LOCALE,
@@ -98,6 +98,7 @@ export const USAGE_SPIKE_ALERT_ENABLED_KEY = "usageSpikeAlertEnabled";
 export const USAGE_SPIKE_ALERT_THRESHOLD_PCT_KEY = "usageSpikeAlertThresholdPct";
 
 const UI_SCALE_KEY = "uiScale";
+const REDUCE_ANIMATIONS_KEY = "reduceAnimations";
 const SHOW_TRAY_ICON_KEY = "showTrayIcon";
 const SHOW_TRAY_INSIGHT_KEY = "showTrayInsight";
 const SHOW_TOTAL_SPEND_KEY = "showTotalSpend";
@@ -133,6 +134,7 @@ export const DEFAULT_USAGE_SPIKE_ALERT_THRESHOLD_PCT: UsageSpikeAlertThresholdPc
 
 export type UIScale = "normal" | "small" | "compact";
 export const DEFAULT_UI_SCALE: UIScale = "normal";
+export const DEFAULT_REDUCE_ANIMATIONS = false;
 const UI_SCALE_VALUES: UIScale[] = ["normal", "small", "compact"];
 export const UI_SCALE_OPTIONS: { value: UIScale; label: string }[] = [
   { value: "normal", label: "Normal" },
@@ -1015,6 +1017,16 @@ export async function saveUIScale(value: UIScale): Promise<void> {
   await store.save();
 }
 
+export async function loadReduceAnimations(): Promise<boolean> {
+  const stored = await store.get<unknown>(REDUCE_ANIMATIONS_KEY);
+  return typeof stored === "boolean" ? stored : DEFAULT_REDUCE_ANIMATIONS;
+}
+
+export async function saveReduceAnimations(value: boolean): Promise<void> {
+  await store.set(REDUCE_ANIMATIONS_KEY, value);
+  await store.save();
+}
+
 export async function loadShowTrayIcon(): Promise<boolean> {
   const stored = await store.get<unknown>(SHOW_TRAY_ICON_KEY);
   if (typeof stored === "boolean") return stored;
@@ -1250,5 +1262,41 @@ export async function loadNotifiedNewProviders(): Promise<string[]> {
 export async function saveNotifiedNewProviders(ids: string[]): Promise<void> {
   const unique = [...new Set(ids.filter(Boolean))];
   await store.set(NOTIFIED_NEW_PROVIDERS_KEY, unique);
+  await store.save();
+}
+
+/** Restore UI preferences to defaults. Does not wipe plugin enablement, credentials, or poll identity. */
+export async function resetAllUserPreferences(): Promise<void> {
+  await store.set(AUTO_UPDATE_SETTINGS_KEY, DEFAULT_AUTO_UPDATE_INTERVAL);
+  await store.set(THEME_MODE_KEY, DEFAULT_THEME_MODE);
+  await store.set(DISPLAY_MODE_KEY, DEFAULT_DISPLAY_MODE);
+  await store.set(RESET_TIMER_DISPLAY_MODE_KEY, DEFAULT_RESET_TIMER_DISPLAY_MODE);
+  await store.set(TIME_FORMAT_MODE_KEY, DEFAULT_TIME_FORMAT_MODE);
+  await store.set(APP_LOCALE_KEY, DEFAULT_APP_LOCALE);
+  await store.set(DISPLAY_CURRENCY_KEY, DEFAULT_DISPLAY_CURRENCY);
+  await store.set(MENUBAR_ICON_STYLE_KEY, DEFAULT_MENUBAR_ICON_STYLE);
+  await store.set(PREFER_MENUBAR_WEEKLY_LIMIT_KEY, DEFAULT_PREFER_MENUBAR_WEEKLY_LIMIT);
+  await store.set(GLOBAL_SHORTCUT_KEY, DEFAULT_GLOBAL_SHORTCUT);
+  await store.set(START_ON_LOGIN_KEY, DEFAULT_START_ON_LOGIN);
+  await store.set(USAGE_ALERT_ENABLED_KEY, DEFAULT_USAGE_ALERT_ENABLED);
+  await store.set(USAGE_ALERT_THRESHOLD_KEY, DEFAULT_USAGE_ALERT_THRESHOLD);
+  await store.set(USAGE_ALERT_CUSTOM_THRESHOLD_KEY, DEFAULT_USAGE_ALERT_CUSTOM_THRESHOLD);
+  await store.set(USAGE_ALERT_SOUND_KEY, DEFAULT_USAGE_ALERT_SOUND);
+  await store.set(USAGE_PACE_ALERT_ENABLED_KEY, DEFAULT_USAGE_PACE_ALERT_ENABLED);
+  await store.set(USAGE_SPIKE_ALERT_ENABLED_KEY, DEFAULT_USAGE_SPIKE_ALERT_ENABLED);
+  await store.set(USAGE_SPIKE_ALERT_THRESHOLD_PCT_KEY, DEFAULT_USAGE_SPIKE_ALERT_THRESHOLD_PCT);
+  await store.set(UI_SCALE_KEY, DEFAULT_UI_SCALE);
+  await store.set(REDUCE_ANIMATIONS_KEY, DEFAULT_REDUCE_ANIMATIONS);
+  await store.set(SHOW_TRAY_ICON_KEY, DEFAULT_SHOW_TRAY_ICON);
+  await store.set(SHOW_TRAY_INSIGHT_KEY, DEFAULT_SHOW_TRAY_INSIGHT);
+  await store.set(SHOW_TOTAL_SPEND_KEY, DEFAULT_SHOW_TOTAL_SPEND);
+  await store.set(TOTAL_SPEND_METRIC_KEY, DEFAULT_TOTAL_SPEND_METRIC);
+  await store.set(SHOW_ACCOUNT_IDENTITY_KEY, DEFAULT_SHOW_ACCOUNT_IDENTITY);
+  await store.set(UI_LAYOUT_KEY, DEFAULT_UI_LAYOUT);
+  await store.set(MODERN_DENSITY_KEY, DEFAULT_MODERN_DENSITY);
+  await store.set(MODERN_LAYOUT_KEY, EMPTY_MODERN_LAYOUT);
+  await store.set(PERSIST_USAGE_HISTORY_KEY, false);
+  await store.set(USAGE_HISTORY_RETENTION_DAYS_KEY, DEFAULT_USAGE_HISTORY_RETENTION_DAYS);
+  await store.set(PRODUCT_POLLS_ENABLED_KEY, DEFAULT_PRODUCT_POLLS_ENABLED);
   await store.save();
 }

--- a/src/motion-fx.css
+++ b/src/motion-fx.css
@@ -1,0 +1,473 @@
+/* Extra FX layered on motion.css. Kill: html.reduce-animations + prefers-reduced-motion. */
+
+.app-panel-surface > .motion-field {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+  border-radius: inherit;
+}
+
+.motion-aurora {
+  position: absolute;
+  inset: -45%;
+  background: conic-gradient(
+    from 0deg,
+    color-mix(in srgb, var(--primary) 35%, transparent),
+    color-mix(in srgb, var(--page-accent, var(--primary)) 18%, transparent),
+    transparent 42%,
+    color-mix(in srgb, var(--destructive) 16%, transparent),
+    transparent 70%,
+    color-mix(in srgb, var(--primary) 28%, transparent)
+  );
+  animation: motion-aurora-spin 14s linear infinite;
+  opacity: 0.16;
+  filter: blur(28px);
+}
+
+.motion-aurora-alt {
+  inset: -55%;
+  animation-direction: reverse;
+  animation-duration: 22s;
+  opacity: 0.1;
+  filter: blur(42px);
+}
+
+.motion-grid {
+  position: absolute;
+  inset: -14%;
+  background-image:
+    linear-gradient(color-mix(in srgb, var(--primary) 14%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--primary) 14%, transparent) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.18;
+  transform: translate(
+    calc((var(--mx, 0.5) - 0.5) * 16px),
+    calc((var(--my, 0.5) - 0.5) * 16px)
+  );
+  transition: transform 0.16s ease-out;
+  mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+}
+
+.motion-dust {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  opacity: 0.4;
+}
+
+.motion-dust::before,
+.motion-dust::after {
+  content: "";
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, white 80%, var(--primary));
+  box-shadow:
+    8vw 12vh 0 0 color-mix(in srgb, white 70%, transparent),
+    22vw 28vh 0 0.5px color-mix(in srgb, var(--primary) 80%, white),
+    41vw 9vh 0 0 color-mix(in srgb, white 60%, transparent),
+    63vw 44vh 0 0.5px color-mix(in srgb, white 75%, transparent),
+    81vw 18vh 0 0 color-mix(in srgb, var(--primary) 70%, white),
+    14vw 62vh 0 0 color-mix(in srgb, white 55%, transparent),
+    36vw 78vh 0 0.5px color-mix(in srgb, white 70%, transparent),
+    58vw 71vh 0 0 color-mix(in srgb, var(--primary) 65%, white),
+    74vw 88vh 0 0 color-mix(in srgb, white 50%, transparent),
+    91vw 55vh 0 0.5px color-mix(in srgb, white 65%, transparent),
+    5vw 91vh 0 0 color-mix(in srgb, var(--primary) 60%, white),
+    48vw 36vh 0 0 color-mix(in srgb, white 60%, transparent);
+  animation: motion-dust-drift 16s linear infinite;
+}
+
+.motion-dust::after {
+  animation-duration: 22s;
+  animation-direction: reverse;
+  opacity: 0.55;
+}
+
+.motion-orb {
+  position: absolute;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary) 55%, white);
+  filter: blur(10px);
+  opacity: 0.28;
+  animation: motion-orb-fly var(--orb-t, 9s) ease-in-out infinite;
+  animation-delay: var(--orb-d, 0s);
+  width: var(--orb-s, 42px);
+  height: var(--orb-s, 42px);
+  left: var(--orb-x, 20%);
+  top: var(--orb-y, 30%);
+}
+
+.motion-shock-ring {
+  position: absolute;
+  left: 50%;
+  top: 46%;
+  width: 24px;
+  height: 24px;
+  margin: -12px 0 0 -12px;
+  border-radius: 999px;
+  border: 2px solid var(--primary);
+  animation: motion-shockwave 0.75s ease-out forwards;
+}
+
+.motion-sparks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.motion-sparks::before,
+.motion-sparks::after {
+  content: "";
+  position: absolute;
+  top: 15%;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: white;
+  box-shadow:
+    12px 2px 0 0 color-mix(in srgb, white 80%, transparent),
+    28px -3px 0 0 color-mix(in srgb, white 70%, transparent),
+    44px 4px 0 0 color-mix(in srgb, white 60%, transparent);
+  animation: motion-spark-run 1.1s linear infinite;
+}
+
+.motion-sparks::after {
+  animation-delay: 0.45s;
+  top: 55%;
+  opacity: 0.7;
+}
+
+.motion-bar-fill::after {
+  animation: motion-sheen 1.6s ease-in-out infinite;
+}
+
+.motion-card {
+  animation: motion-card-float 4.6s ease-in-out infinite;
+}
+
+.motion-stagger > .motion-card {
+  animation:
+    motion-rise 0.72s var(--motion-spring) both,
+    motion-card-float 4.6s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * 70ms), calc(0.75s + var(--i, 0) * 70ms);
+}
+
+.app-main-pane {
+  animation: motion-pane-in 0.7s var(--motion-out) 0.08s backwards;
+}
+
+.motion-view {
+  animation: motion-view-flip 0.45s var(--motion-out) both;
+}
+
+.motion-nav-btn:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--primary) 55%, transparent));
+}
+
+.motion-tab[data-active="true"] {
+  animation: motion-tab-pop 0.55s var(--motion-spring) both;
+  box-shadow: 0 0 18px color-mix(in srgb, var(--primary) 45%, transparent);
+}
+
+.motion-tick:active {
+  transform: scale(0.88) rotate(-18deg);
+}
+
+.motion-number {
+  display: inline-block;
+  animation: motion-number-pop 0.45s var(--motion-spring);
+}
+
+.motion-cursor,
+.motion-cursor-lag {
+  position: absolute;
+  left: calc(var(--mx, 0.5) * 100%);
+  top: calc(var(--my, 0.5) * 100%);
+  width: 88px;
+  height: 88px;
+  margin: -44px 0 0 -44px;
+  border-radius: 999px;
+  pointer-events: none;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--primary) 55%, white) 0%,
+    transparent 70%
+  );
+  filter: blur(6px);
+  opacity: 0.55;
+  transition: left 0.07s linear, top 0.07s linear;
+}
+
+.motion-cursor-lag {
+  width: 150px;
+  height: 150px;
+  margin: -75px 0 0 -75px;
+  opacity: 0.22;
+  transition: left 0.32s ease-out, top 0.32s ease-out;
+}
+
+.motion-scan {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 18%;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--primary) 28%, transparent),
+    transparent
+  );
+  animation: motion-scan-y 2.8s linear infinite;
+  opacity: 0.55;
+}
+
+.motion-scan-slow {
+  height: 9%;
+  opacity: 0.28;
+  animation-duration: 5.4s;
+  animation-delay: 1.6s;
+}
+
+.motion-cursor-spark {
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  opacity: 0.85;
+  filter: blur(1px);
+  transition: left 0.04s linear, top 0.04s linear;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, white 90%, var(--primary)) 0%,
+    transparent 72%
+  );
+}
+
+.motion-edge {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 35%, transparent);
+  animation: motion-edge-pulse 2.2s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.motion-title {
+  animation: motion-title-glow 2.8s ease-in-out infinite;
+}
+
+.motion-press {
+  transition: transform 0.2s var(--motion-spring);
+}
+
+.motion-press:hover {
+  transform: scale(1.03);
+}
+
+.motion-press:active {
+  transform: scale(0.97);
+}
+
+.motion-nav-btn[data-active="true"] {
+  animation: motion-nav-glow 2.4s ease-in-out infinite;
+}
+
+.motion-bar-fill {
+  animation: motion-bar-glow 2.4s ease-in-out infinite;
+}
+
+.motion-shock-late {
+  animation-delay: 90ms;
+  border-color: color-mix(in srgb, var(--primary) 50%, white);
+}
+.motion-shock-later {
+  animation-delay: 180ms;
+  opacity: 0.6;
+}
+
+@keyframes motion-aurora-spin {
+  to {
+    transform: rotate(360deg) scale(1.08);
+  }
+}
+
+@keyframes motion-dust-drift {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-28%);
+  }
+}
+
+@keyframes motion-orb-fly {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  35% {
+    transform: translate(42px, -28px) scale(1.35);
+  }
+  70% {
+    transform: translate(-24px, 36px) scale(0.82);
+  }
+}
+
+@keyframes motion-shockwave {
+  0% {
+    transform: scale(0.4);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(28);
+    opacity: 0;
+  }
+}
+
+@keyframes motion-spark-run {
+  from {
+    transform: translateX(-20%);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  to {
+    transform: translateX(220%);
+    opacity: 0;
+  }
+}
+
+@keyframes motion-card-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -2px;
+  }
+}
+
+@keyframes motion-view-flip {
+  from {
+    opacity: 0;
+    transform: translateX(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes motion-number-pop {
+  0% {
+    transform: scale(1.18) translateY(-2px);
+    filter: brightness(1.4);
+  }
+  100% {
+    transform: none;
+    filter: none;
+  }
+}
+
+@keyframes motion-scan-y {
+  from {
+    transform: translateY(-40%);
+  }
+  to {
+    transform: translateY(420%);
+  }
+}
+
+@keyframes motion-edge-pulse {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--primary) 20%, transparent);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--primary) 70%, transparent),
+      inset 0 0 24px color-mix(in srgb, var(--primary) 18%, transparent);
+  }
+}
+
+@keyframes motion-title-glow {
+  0%,
+  100% {
+    text-shadow: none;
+  }
+  50% {
+    text-shadow: 0 0 14px color-mix(in srgb, var(--primary) 55%, transparent);
+  }
+}
+
+@keyframes motion-nav-glow {
+  0%,
+  100% {
+    filter: none;
+  }
+  50% {
+    filter: drop-shadow(0 0 8px color-mix(in srgb, var(--primary) 55%, transparent));
+  }
+}
+
+@keyframes motion-bar-glow {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.18);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-field,
+  .motion-aurora,
+  .motion-sparks,
+  .motion-shock-ring,
+  .motion-cursor,
+  .motion-cursor-lag,
+  .motion-scan,
+  .motion-orb,
+  .motion-edge,
+  .motion-grid,
+  .motion-dust {
+    display: none !important;
+    animation: none !important;
+  }
+}
+
+html.reduce-animations .motion-field,
+html.reduce-animations .motion-aurora,
+html.reduce-animations .motion-sparks,
+html.reduce-animations .motion-shock-ring,
+html.reduce-animations .motion-cursor,
+html.reduce-animations .motion-cursor-lag,
+html.reduce-animations .motion-scan,
+html.reduce-animations .motion-orb,
+html.reduce-animations .motion-edge,
+html.reduce-animations .motion-grid,
+html.reduce-animations .motion-dust {
+  display: none !important;
+  animation: none !important;
+}
+
+html.reduce-animations .motion-title {
+  animation: none !important;
+  text-shadow: none !important;
+}
+
+html.reduce-animations .app-main-pane,
+html.reduce-animations .motion-card,
+html.reduce-animations .motion-stagger > .motion-card,
+html.reduce-animations .motion-view {
+  animation: none !important;
+  translate: none !important;
+  transform: none !important;
+}

--- a/src/motion.css
+++ b/src/motion.css
@@ -1,0 +1,336 @@
+/* CrossUsage motion system. Kill switch: html.reduce-animations + prefers-reduced-motion. */
+
+:root {
+  --motion-spring: cubic-bezier(0.16, 1.32, 0.32, 1);
+  --motion-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --motion-in: cubic-bezier(0.64, 0, 0.78, 0);
+}
+
+.app-panel-surface {
+  --mx: 0.5;
+  --my: 0.5;
+  isolation: isolate;
+  animation: motion-panel-in 0.7s var(--motion-spring) backwards;
+}
+
+.app-panel-surface > * {
+  position: relative;
+  z-index: 1;
+}
+
+.app-panel-surface::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    380px circle at calc(var(--mx) * 100%) calc(var(--my) * 100%),
+    color-mix(in srgb, var(--primary) 22%, transparent),
+    transparent 62%
+  );
+  opacity: 0.4;
+  transition: opacity 0.4s var(--motion-out);
+}
+
+.app-main-pane,
+.app-panel-surface > nav {
+  animation: motion-pane-in 0.7s var(--motion-out) 0.08s both;
+}
+
+.motion-view {
+  animation: motion-view-in 0.48s var(--motion-out) both;
+}
+
+.motion-stagger > * {
+  animation: motion-rise 0.72s var(--motion-spring) both;
+  animation-delay: calc(var(--i, 0) * 70ms);
+}
+
+.motion-card {
+  transition:
+    transform 0.45s var(--motion-spring),
+    box-shadow 0.45s var(--motion-out),
+    filter 0.45s var(--motion-out),
+    border-color 0.3s ease;
+}
+
+.motion-card:hover {
+  transform: translateY(-3px);
+  box-shadow:
+    0 12px 28px -16px color-mix(in srgb, var(--foreground) 28%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--primary) 28%, transparent);
+  filter: saturate(1.08);
+  z-index: 2;
+}
+
+.motion-nav-btn {
+  transition:
+    transform 0.35s var(--motion-spring),
+    background-color 0.25s ease,
+    color 0.25s ease;
+}
+
+.motion-nav-btn:hover {
+  transform: scale(1.05);
+}
+
+.motion-nav-btn:active {
+  transform: scale(0.92);
+}
+
+.motion-nav-btn[data-active="true"]::before {
+  animation: motion-rail 0.45s var(--motion-spring) both;
+  box-shadow: 0 0 12px var(--primary);
+}
+
+.motion-tab {
+  transition:
+    transform 0.35s var(--motion-spring),
+    background-color 0.25s ease,
+    color 0.2s ease,
+    box-shadow 0.35s var(--motion-out);
+}
+
+.motion-tab:hover {
+  transform: translateY(-1px) scale(1.03);
+}
+
+.motion-tab[data-active="true"] {
+  animation: motion-tab-pop 0.5s var(--motion-spring) both;
+}
+
+.motion-bar-fill {
+  position: relative;
+  overflow: hidden;
+  transition:
+    width 0.85s var(--motion-spring),
+    background-color 0.4s ease,
+    filter 0.4s ease;
+}
+
+.motion-bar-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 35%,
+    color-mix(in srgb, white 55%, transparent) 50%,
+    transparent 65%
+  );
+  animation: motion-sheen 1.8s var(--motion-out) both;
+  pointer-events: none;
+}
+
+.motion-bar-hot {
+  animation: motion-heat 1.1s ease-in-out infinite;
+  filter: saturate(1.35);
+}
+
+.motion-dot {
+  animation: motion-breathe 1.8s ease-in-out infinite;
+}
+
+.motion-ping {
+  animation: motion-ping 1.6s var(--motion-out) infinite;
+}
+
+.motion-tick {
+  transition: transform 0.35s var(--motion-spring), color 0.2s ease;
+}
+
+.motion-tick:hover {
+  transform: scale(1.08);
+}
+
+.motion-tick:active {
+  transform: scale(0.94) rotate(-8deg);
+}
+
+.motion-spin-boost {
+  animation: motion-spin 0.7s linear infinite;
+}
+
+@keyframes motion-panel-in {
+  0% {
+    opacity: 0;
+    filter: blur(8px);
+    transform: translateY(16px) scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+}
+
+@keyframes motion-pane-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes motion-view-in {
+  from {
+    opacity: 0;
+    transform: translateX(18px) scale(0.97);
+    filter: blur(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+}
+
+@keyframes motion-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes motion-rail {
+  from {
+    transform: scaleY(0.2);
+    opacity: 0;
+  }
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}
+
+@keyframes motion-tab-pop {
+  0% {
+    transform: scale(0.92);
+  }
+  70% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: none;
+  }
+}
+
+@keyframes motion-sheen {
+  from {
+    transform: translateX(-120%);
+  }
+  to {
+    transform: translateX(120%);
+  }
+}
+
+@keyframes motion-heat {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--destructive) 0%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 18px 2px color-mix(in srgb, var(--destructive) 55%, transparent);
+  }
+}
+
+@keyframes motion-breathe {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.55);
+    opacity: 1;
+  }
+}
+
+@keyframes motion-ping {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--primary) 70%, transparent);
+  }
+  80%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+@keyframes motion-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+
+  .app-panel-surface,
+  .motion-card,
+  .motion-nav-btn,
+  .motion-tab,
+  .motion-tick,
+  .motion-dot,
+  .motion-view {
+    transform: none !important;
+    filter: none !important;
+    box-shadow: none !important;
+  }
+
+  .app-panel-surface::before {
+    display: none !important;
+  }
+}
+
+html.reduce-animations,
+html.reduce-animations *,
+html.reduce-animations *::before,
+html.reduce-animations *::after {
+  animation: none !important;
+  transition: none !important;
+  scroll-behavior: auto !important;
+}
+
+html.reduce-animations .app-panel-surface,
+html.reduce-animations .motion-card,
+html.reduce-animations .motion-nav-btn,
+html.reduce-animations .motion-tab,
+html.reduce-animations .motion-tick,
+html.reduce-animations .motion-dot,
+html.reduce-animations .motion-view,
+html.reduce-animations .motion-stagger > * {
+  transform: none !important;
+  filter: none !important;
+  animation: none !important;
+}
+
+html.reduce-animations .app-panel-surface::before,
+html.reduce-animations .motion-bar-fill::after {
+  display: none !important;
+}
+
+html.reduce-animations .motion-card:hover,
+html.reduce-animations .motion-nav-btn:hover,
+html.reduce-animations .motion-tab:hover,
+html.reduce-animations .motion-tick:hover {
+  transform: none !important;
+  box-shadow: none !important;
+  filter: none !important;
+}

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -75,7 +75,8 @@ export function OverviewPage({
   }
 
   return (
-    <div>
+    <div className="motion-stagger">
+      <div className="motion-card" style={{ ["--i" as string]: 0 }}>
       <UsageInsightsBanner
         insights={insights}
         historyTightest={historyInsights?.tightest}
@@ -86,9 +87,14 @@ export function OverviewPage({
         nowMs={nowMs}
         onSelectProvider={setActiveView}
       />
+      </div>
       {plugins.map((plugin, index) => (
-        <ProviderCard
+        <div
           key={plugin.meta.id}
+          className="motion-card"
+          style={{ ["--i" as string]: index + 1 }}
+        >
+        <ProviderCard
           name={plugin.meta.name}
           plan={plugin.data?.plan}
           showSeparator={index < plugins.length - 1}
@@ -108,6 +114,7 @@ export function OverviewPage({
           timeFormatMode={timeFormatMode}
           showAccountIdentity={showAccountIdentity}
         />
+        </div>
       ))}
     </div>
   )

--- a/src/pages/settings.test.tsx
+++ b/src/pages/settings.test.tsx
@@ -1,7 +1,22 @@
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import userEvent from "@testing-library/user-event"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const tauriMocks = vi.hoisted(() => ({
+  invoke: vi.fn(() => Promise.resolve()),
+  isTauri: vi.fn(() => false),
+}))
+
+const settingsMocks = vi.hoisted(() => ({
+  resetAllUserPreferences: vi.fn(() => Promise.resolve()),
+  loadPersistUsageHistory: vi.fn(() => Promise.resolve(false)),
+  loadUsageHistoryRetentionDays: vi.fn(() => Promise.resolve(90)),
+}))
+
+const autostartMocks = vi.hoisted(() => ({
+  disable: vi.fn(() => Promise.resolve()),
+}))
 
 let latestOnDragEnd: ((event: any) => void) | undefined
 
@@ -44,6 +59,25 @@ vi.mock("@dnd-kit/utilities", () => ({
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(() => Promise.resolve()),
 }))
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: tauriMocks.invoke,
+  isTauri: tauriMocks.isTauri,
+}))
+
+vi.mock("@tauri-apps/plugin-autostart", () => ({
+  disable: autostartMocks.disable,
+}))
+
+vi.mock("@/lib/settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/settings")>()
+  return {
+    ...actual,
+    resetAllUserPreferences: settingsMocks.resetAllUserPreferences,
+    loadPersistUsageHistory: settingsMocks.loadPersistUsageHistory,
+    loadUsageHistoryRetentionDays: settingsMocks.loadUsageHistoryRetentionDays,
+  }
+})
 
 import { openUrl } from "@tauri-apps/plugin-opener"
 import { SettingsPage } from "@/pages/settings"
@@ -123,6 +157,15 @@ const defaultProps = {
 
 afterEach(() => {
   cleanup()
+})
+
+beforeEach(() => {
+  tauriMocks.invoke.mockResolvedValue(undefined)
+  tauriMocks.isTauri.mockReturnValue(false)
+  settingsMocks.resetAllUserPreferences.mockResolvedValue(undefined)
+  settingsMocks.loadPersistUsageHistory.mockResolvedValue(false)
+  settingsMocks.loadUsageHistoryRetentionDays.mockResolvedValue(90)
+  autostartMocks.disable.mockResolvedValue(undefined)
 })
 
 describe("SettingsPage", () => {
@@ -445,5 +488,46 @@ describe("SettingsPage", () => {
     })
     await userEvent.click(screen.getByText("Show account identity"))
     expect(onShowAccountIdentityChange).toHaveBeenCalledWith(true)
+  })
+
+  it("clears the OS global shortcut when resetting all settings", async () => {
+    tauriMocks.isTauri.mockReturnValue(true)
+    vi.spyOn(window, "confirm").mockReturnValue(true)
+    renderSettings({ ...defaultProps })
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset all settings" }))
+
+    await waitFor(() => {
+      expect(settingsMocks.resetAllUserPreferences).toHaveBeenCalled()
+      expect(tauriMocks.invoke).toHaveBeenCalledWith("update_global_shortcut", {
+        shortcut: null,
+      })
+    })
+  })
+
+  it("reloads usage-history controls after reset so persist matches defaults", async () => {
+    settingsMocks.loadPersistUsageHistory.mockResolvedValue(true)
+    vi.spyOn(window, "confirm").mockReturnValue(true)
+    renderSettings({ ...defaultProps })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("checkbox", {
+          name: "Save usage snapshots after successful refreshes",
+        }),
+      ).toBeChecked()
+    })
+
+    settingsMocks.loadPersistUsageHistory.mockResolvedValue(false)
+    await userEvent.click(screen.getByRole("button", { name: "Reset all settings" }))
+
+    await waitFor(() => {
+      expect(settingsMocks.resetAllUserPreferences).toHaveBeenCalled()
+      expect(
+        screen.getByRole("checkbox", {
+          name: "Save usage snapshots after successful refreshes",
+        }),
+      ).not.toBeChecked()
+    })
   })
 })

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -40,6 +40,7 @@ import {
   saveShowTotalSpend,
   saveReduceAnimations,
   resetAllUserPreferences,
+  DEFAULT_GLOBAL_SHORTCUT,
   DEFAULT_START_ON_LOGIN,
   type AutoUpdateIntervalMinutes,
   type DisplayMode,
@@ -792,7 +793,7 @@ function ReduceAnimationsSection() {
   );
 }
 
-function ResetAllSettingsSection() {
+function ResetAllSettingsSection({ onResetComplete }: { onResetComplete: () => void }) {
   const { t } = useTranslation();
   const resetState = useAppPreferencesStore((s) => s.resetState);
   const [busy, setBusy] = useState(false);
@@ -803,6 +804,14 @@ function ResetAllSettingsSection() {
     try {
       await resetAllUserPreferences();
       resetState();
+      onResetComplete();
+      if (isTauri()) {
+        try {
+          await invoke("update_global_shortcut", { shortcut: DEFAULT_GLOBAL_SHORTCUT });
+        } catch (e) {
+          console.error("update global shortcut after reset:", e);
+        }
+      }
       await hydrateModernLayoutStore();
       await setProductPollsEnabled(true);
       if (isTauri() && !DEFAULT_START_ON_LOGIN) {
@@ -1338,6 +1347,7 @@ export function SettingsPage({
     nextStyle: MenubarIconStyle;
     selectedLine: string;
   } | null>(null);
+  const [usageHistorySectionKey, setUsageHistorySectionKey] = useState(0);
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -1877,7 +1887,7 @@ export function SettingsPage({
       <InsightsSection />
       <ProductPollsSection />
       <LocalApiSection />
-      <UsageHistorySection />
+      <UsageHistorySection key={usageHistorySectionKey} />
       <section>
         <h3 className="text-lg font-semibold mb-0">Troubleshooting</h3>
         <p className="text-sm text-muted-foreground mb-2">
@@ -2014,7 +2024,7 @@ export function SettingsPage({
           ) : null}
         </div>
       </section>
-      <ResetAllSettingsSection />
+      <ResetAllSettingsSection onResetComplete={() => setUsageHistorySectionKey((k) => k + 1)} />
       <section>
         <h3 className="text-lg font-semibold mb-0">Account Identity</h3>
         <p className="text-sm text-muted-foreground mb-2">

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -18,6 +18,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { useState, useEffect, useCallback, useMemo, type ReactNode } from "react";
 import { GripVertical } from "lucide-react";
 import { invoke, isTauri } from "@tauri-apps/api/core";
+import { disable as disableAutostart } from "@tauri-apps/plugin-autostart";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
@@ -37,6 +38,9 @@ import {
   saveUsageHistoryRetentionDays,
   saveShowTrayInsight,
   saveShowTotalSpend,
+  saveReduceAnimations,
+  resetAllUserPreferences,
+  DEFAULT_START_ON_LOGIN,
   type AutoUpdateIntervalMinutes,
   type DisplayMode,
   type GlobalShortcut,
@@ -52,6 +56,7 @@ import {
   type UsageAlertSound,
   type UsageAlertThreshold,
 } from "@/lib/settings";
+import { hydrateModernLayoutStore } from "@/stores/modern-layout-store";
 import { setProductPollsEnabled } from "@/hooks/app/use-product-polls";
 import { useProductPollsStore } from "@/stores/product-polls-store";
 import { DEFAULT_LOG_LEVEL, isLogLevel, LOG_LEVEL_OPTIONS, type LogLevel } from "@/lib/log-level";
@@ -73,6 +78,7 @@ import { formatOsDiagnosticsLine, type OsDiagnosticsPayload } from "@/lib/os-dia
 import { cn } from "@/lib/utils";
 import { LayoutPreviewClassic, LayoutPreviewModern } from "@/components/ui-layout-preview";
 import { useAppPreferencesStore } from "@/stores/app-preferences-store";
+import { fireMotionShock } from "@/components/motion-field";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { multiAccountCredentialsGuideUrl } from "@/lib/docs-links";
 import { FORK_REPO_URL } from "@/lib/fork-meta";
@@ -748,6 +754,87 @@ function ProductPollsSection() {
         />
         Allow product polls
       </label>
+    </section>
+  );
+}
+
+function ReduceAnimationsSection() {
+  const { t } = useTranslation();
+  const reduceAnimations = useAppPreferencesStore((s) => s.reduceAnimations);
+  const setReduceAnimations = useAppPreferencesStore((s) => s.setReduceAnimations);
+
+  const onChange = async (checked: boolean) => {
+    const prev = reduceAnimations;
+    setReduceAnimations(checked);
+    if (!checked) fireMotionShock();
+    try {
+      await saveReduceAnimations(checked);
+    } catch (e) {
+      console.error(e);
+      setReduceAnimations(prev);
+    }
+  };
+
+  return (
+    <section>
+      <h3 className="text-lg font-semibold mb-0">{t("settings.reduceAnimations.title")}</h3>
+      <p className="text-sm text-muted-foreground mb-2">
+        {t("settings.reduceAnimations.description")}
+      </p>
+      <label className="flex items-center gap-2 text-sm select-none text-foreground">
+        <Checkbox
+          checked={reduceAnimations}
+          onCheckedChange={(checked) => void onChange(checked === true)}
+        />
+        {t("settings.reduceAnimations.checkbox")}
+      </label>
+    </section>
+  );
+}
+
+function ResetAllSettingsSection() {
+  const { t } = useTranslation();
+  const resetState = useAppPreferencesStore((s) => s.resetState);
+  const [busy, setBusy] = useState(false);
+
+  const onReset = async () => {
+    if (!window.confirm(t("settings.resetAll.confirm"))) return;
+    setBusy(true);
+    try {
+      await resetAllUserPreferences();
+      resetState();
+      await hydrateModernLayoutStore();
+      await setProductPollsEnabled(true);
+      if (isTauri() && !DEFAULT_START_ON_LOGIN) {
+        try {
+          await disableAutostart();
+        } catch (e) {
+          console.error("disable autostart after reset:", e);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section>
+      <h3 className="text-lg font-semibold mb-0">{t("settings.resetAll.title")}</h3>
+      <p className="text-sm text-muted-foreground mb-2">
+        {t("settings.resetAll.description")}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="text-destructive border-destructive/50 hover:bg-destructive/10"
+        disabled={busy}
+        onClick={() => void onReset()}
+      >
+        {t("settings.resetAll.button")}
+      </Button>
     </section>
   );
 }
@@ -1759,6 +1846,7 @@ export function SettingsPage({
           </div>
         </div>
       </section>
+      <ReduceAnimationsSection />
       </>
       ) : null}
       {showModernSection("advanced") ? (
@@ -1926,6 +2014,7 @@ export function SettingsPage({
           ) : null}
         </div>
       </section>
+      <ResetAllSettingsSection />
       <section>
         <h3 className="text-lg font-semibold mb-0">Account Identity</h3>
         <p className="text-sm text-muted-foreground mb-2">

--- a/src/stores/app-preferences-store.ts
+++ b/src/stores/app-preferences-store.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_USAGE_SPIKE_ALERT_ENABLED,
   DEFAULT_USAGE_SPIKE_ALERT_THRESHOLD_PCT,
   DEFAULT_USAGE_ALERT_THRESHOLD,
+  DEFAULT_REDUCE_ANIMATIONS,
   type AutoUpdateIntervalMinutes,
   type DisplayMode,
   type UIScale,
@@ -70,6 +71,7 @@ type AppPreferencesStore = {
   usagePaceAlertEnabled: boolean
   usageSpikeAlertEnabled: boolean
   usageSpikeAlertThresholdPct: UsageSpikeAlertThresholdPct
+  reduceAnimations: boolean
   onboardingComplete: boolean | null
   exchangeRatesRevision: number
 
@@ -99,6 +101,7 @@ type AppPreferencesStore = {
   setUsagePaceAlertEnabled: (value: boolean) => void
   setUsageSpikeAlertEnabled: (value: boolean) => void
   setUsageSpikeAlertThresholdPct: (value: UsageSpikeAlertThresholdPct) => void
+  setReduceAnimations: (value: boolean) => void
   setOnboardingComplete: (value: boolean) => void
   bumpExchangeRatesRevision: () => void
   resetState: () => void
@@ -131,6 +134,7 @@ const initialState = {
   usagePaceAlertEnabled: DEFAULT_USAGE_PACE_ALERT_ENABLED,
   usageSpikeAlertEnabled: DEFAULT_USAGE_SPIKE_ALERT_ENABLED,
   usageSpikeAlertThresholdPct: DEFAULT_USAGE_SPIKE_ALERT_THRESHOLD_PCT,
+  reduceAnimations: DEFAULT_REDUCE_ANIMATIONS,
   onboardingComplete: null as boolean | null,
   exchangeRatesRevision: 0,
 }
@@ -163,6 +167,7 @@ export const useAppPreferencesStore = create<AppPreferencesStore>((set) => ({
   setUsagePaceAlertEnabled: (value) => set({ usagePaceAlertEnabled: value }),
   setUsageSpikeAlertEnabled: (value) => set({ usageSpikeAlertEnabled: value }),
   setUsageSpikeAlertThresholdPct: (value) => set({ usageSpikeAlertThresholdPct: value }),
+  setReduceAnimations: (value) => set({ reduceAnimations: value }),
   setOnboardingComplete: (value) => set({ onboardingComplete: value }),
   bumpExchangeRatesRevision: () =>
     set((state) => ({ exchangeRatesRevision: state.exchangeRatesRevision + 1 })),


### PR DESCRIPTION
## Summary
- Port OpenUsage **v0.7.8 + v0.7.9** as CrossUsage **1.4.1** (PATCH). Public v0.7.7 was never shipped upstream.
- Pricing: Kimi K3, Cursor Router labels, Claude Opus 5, Daybreak Blue, Grok 4.6; Grok 4.5 Fast output $12/MTok. Codex auto-review slug stays; dated fallback is cost-only. OpenCode Go uses `GET /zen/go/v1/usage` when a key exists.
- Settings: Reduce animations + Reset all settings. Motion overlays stay on the background (no panel tilt/zoom, no concentric grain rings, no click ripples).

Tracker: [docs/PORT-0.7.8-0.7.9.md](docs/PORT-0.7.8-0.7.9.md)

## Test plan
- [ ] `bun run test` + `bun run build`
- [ ] `cargo test -p crossusage-cli --locked`
- [ ] Settings → Reduce animations off: dashboard readable, no window tilt, no sonar rings, no click ripple
- [ ] Settings → Reduce animations on: motion overlays gone
- [ ] OpenCode Go with API key shows Session/Weekly/Monthly from the official usage API
- [ ] Footer shows **1.4.1**


Made with [Cursor](https://cursor.com)