### PR TITLE
fix: quiet looping motion on the Modern dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 **CrossUsage** ships **1.x** releases from [github.com/barramee27/crossusage](https://github.com/barramee27/crossusage). Older **0.6.x** sections below are **archived OpenUsage upstream** notes, not CrossUsage release numbers.
 
+## 1.4.2
+
+**Theme:** Quiet Modern dashboard motion. Classic bar sheen/sparks unchanged.
+
+### Bug fixes
+
+- **Modern UI** — drop looping bar sheen/sparks, card float, and the overlay field. Classic layout keeps bar lights and bubbles. Reduce animations still kills remaining FX.
+
+---
+
 ## 1.4.1
 
 **Theme:** OpenUsage **v0.7.8 + v0.7.9** upstream patch (PATCH per [docs/VERSIONING.md](docs/VERSIONING.md)). Robin skipped a public **v0.7.7**. Port tracker: [docs/PORT-0.7.8-0.7.9.md](docs/PORT-0.7.8-0.7.9.md).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "crossusage"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "base64 0.22.1",
  "crossusage-core",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "crossusage-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "crossusage-core"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/crates/crossusage-cli/Cargo.toml
+++ b/crates/crossusage-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossusage-cli"
-version = "1.4.1"
+version = "1.4.2"
 description = "CrossUsage CLI — terminal interface for the same plugin engine as the GUI"
 edition = "2021"
 

--- a/crates/crossusage-core/Cargo.toml
+++ b/crates/crossusage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossusage-core"
-version = "1.4.1"
+version = "1.4.2"
 description = "Shared plugin engine for CrossUsage (GUI + CLI)"
 edition = "2024"
 

--- a/docs/FORK-UPSTREAM.md
+++ b/docs/FORK-UPSTREAM.md
@@ -4,7 +4,7 @@ CrossUsage is the **Tauri Linux/Windows** line. Upstream **OpenUsage 0.7+** is a
 
 **UI diff target:** compare Modern layout work against **`upstream/swift`**, not `upstream/main`. Port spec: [OPENUSAGE-0.7-UI-SPEC.md](./OPENUSAGE-0.7-UI-SPEC.md).
 
-**Release trigger:** **1.2.0** → v0.7.0 Modern UI. **1.3.0** → v0.7.1 + i18n ([PORT-0.7.1.md](./PORT-0.7.1.md)). **1.3.1** → bundled v0.7.2 + v0.7.3 ([PORT-0.7.2-0.7.3.md](./PORT-0.7.2-0.7.3.md)). **1.3.2** → bundled v0.7.4 + v0.7.5 ([PORT-0.7.4-0.7.5.md](./PORT-0.7.4-0.7.5.md)). **1.3.3** → v0.7.6 ([PORT-0.7.6.md](./PORT-0.7.6.md)). **1.4.0** → fork-only features per [VERSIONING.md](./VERSIONING.md). **1.4.1** → v0.7.8 + v0.7.9 ([PORT-0.7.8-0.7.9.md](./PORT-0.7.8-0.7.9.md); public v0.7.7 skipped upstream).
+**Release trigger:** **1.2.0** → v0.7.0 Modern UI. **1.3.0** → v0.7.1 + i18n ([PORT-0.7.1.md](./PORT-0.7.1.md)). **1.3.1** → bundled v0.7.2 + v0.7.3 ([PORT-0.7.2-0.7.3.md](./PORT-0.7.2-0.7.3.md)). **1.3.2** → bundled v0.7.4 + v0.7.5 ([PORT-0.7.4-0.7.5.md](./PORT-0.7.4-0.7.5.md)). **1.3.3** → v0.7.6 ([PORT-0.7.6.md](./PORT-0.7.6.md)). **1.4.0** → fork-only features per [VERSIONING.md](./VERSIONING.md). **1.4.1** → v0.7.8 + v0.7.9 ([PORT-0.7.8-0.7.9.md](./PORT-0.7.8-0.7.9.md); public v0.7.7 skipped upstream). **1.4.2** → Modern motion quiet (no upstream port).
 
 ## What to port
 

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -1,5 +1,9 @@
 # Breadcrumbs
 
+## 2026-08-19
+
+- Quiet **Modern** motion: no bar sheen/sparks, no overlay field, no card float. Classic unchanged.
+
 ## 2026-08-18
 
 - 1.4.1 motion pass 6: removed **concentric grain rings** (the “100 circles”). Restored orbs. Click ripples still off.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -1,5 +1,9 @@
 # Choices
 
+## 2026-08-19
+
+- **Modern vs Classic motion:** Classic keeps bar sheen/sparks (one provider at a time). Modern dashboard drops looping bar lights, card bob, and MotionField overlay — too many meters at once.
+
 ## 2026-08-18
 
 - **Motion vs Reduce animations:** No live 3D/zoom on the whole panel. No concentric grain rings (looked like ~100 circles) and no click ripples. Orbs stay. Pointer drives spotlight/comet/grid. OS reduce-motion still hard-kills.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crossusage",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossusage"
-version = "1.4.1"
+version = "1.4.2"
 description = "CrossUsage — cross-platform fork of OpenUsage, an open source AI subscription limit tracker"
 authors = ["barramee kottanawadee <barramee25038@gmail.com>"]
 homepage = "https://github.com/barramee27/crossusage"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "crossusage",
   "mainBinaryName": "crossusage",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.barramee27.crossusage",
   "build": {
     "beforeDevCommand": "node scripts/tauri-before-dev.cjs",

--- a/src/components/app/app-shell.tsx
+++ b/src/components/app/app-shell.tsx
@@ -111,6 +111,7 @@ export function AppShell({
       <div
         ref={panelMotionRef}
         className="app-panel-surface relative w-full overflow-hidden rounded-[18px] select-none flex flex-col"
+        data-ui-layout="classic"
         style={
           macPopoverChrome && maxPanelHeightPx
             ? { maxHeight: `${maxPanelHeightPx}px` }

--- a/src/components/app/modern-shell.tsx
+++ b/src/components/app/modern-shell.tsx
@@ -43,7 +43,6 @@ import { useProductPollsBadge } from "@/hooks/app/use-product-polls"
 import { useProductPollsStore } from "@/stores/product-polls-store"
 import { PollsPage } from "@/pages/polls"
 import { useMotionPointer } from "@/hooks/app/use-motion-pointer"
-import { MotionField } from "@/components/motion-field"
 
 type ModernScreen = "dashboard" | "customize" | "polls" | "settings"
 
@@ -269,8 +268,8 @@ export function ModernShell({
       <div
         ref={panelMotionRef}
         className="app-panel-surface relative w-full overflow-hidden rounded-[18px] select-none flex flex-col min-h-[320px]"
+        data-ui-layout="modern"
       >
-        <MotionField />
         <nav
           className="flex gap-1 px-3 pt-2 pb-1 border-b border-border/50"
           aria-label="Modern navigation"

--- a/src/components/modern/widget-row.test.tsx
+++ b/src/components/modern/widget-row.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { WidgetRow } from "@/components/modern/widget-row"
+import type { WidgetData } from "@/lib/widget-data"
+
+function meter(over: Partial<WidgetData> = {}): WidgetData {
+  return {
+    metricId: "p:session",
+    label: "Session",
+    displayName: "Test",
+    kind: "progress",
+    bounded: true,
+    used: 90,
+    limit: 100,
+    resetsAt: null,
+    periodDurationMs: null,
+    textValue: "90% used",
+    textSecondary: null,
+    paceStatus: "behind",
+    paceDetail: null,
+    isLimitReached: false,
+    ...over,
+  }
+}
+
+describe("WidgetRow", () => {
+  it("keeps Modern meters static (no bar sheen or sparks)", () => {
+    const { container } = render(<WidgetRow data={meter()} />)
+    expect(container.querySelector(".motion-bar-fill")).toBeNull()
+    expect(container.querySelector(".motion-sparks")).toBeNull()
+    expect(container.querySelector(".motion-bar-hot")).toBeNull()
+  })
+})

--- a/src/components/modern/widget-row.tsx
+++ b/src/components/modern/widget-row.tsx
@@ -218,17 +218,12 @@ export function WidgetRow({ data, compact, className, onRefreshPlugin }: WidgetR
       </div>
       <div className={cn("relative rounded-full bg-muted overflow-hidden", compact ? "h-1" : "h-1.5")}>
         <div
-          className={cn(
-            "h-full rounded-full motion-bar-fill",
-            !fillColor && fillClass,
-            fraction >= 0.85 && "motion-bar-hot",
-          )}
+          className={cn("h-full rounded-full", !fillColor && fillClass)}
           style={{
             width: `${Math.round(fraction * 100)}%`,
             ...(fillColor ? { backgroundColor: fillColor } : {}),
           }}
         />
-        {fraction >= 0.85 ? <span className="motion-sparks" aria-hidden="true" /> : null}
       </div>
       {data.textSecondary ? (
         <p className={cn("text-muted-foreground mt-0.5", compact ? "text-[10px]" : "text-xs")}>

--- a/src/motion-fx.css
+++ b/src/motion-fx.css
@@ -471,3 +471,23 @@ html.reduce-animations .motion-view {
   translate: none !important;
   transform: none !important;
 }
+
+/* Modern dashboard: many bars at once — looping sheen/sparks/card bob is noisy. Classic keeps them. */
+[data-ui-layout="modern"] .motion-bar-fill,
+[data-ui-layout="modern"] .motion-bar-fill::after,
+[data-ui-layout="modern"] .motion-sparks,
+[data-ui-layout="modern"] .motion-bar-hot {
+  animation: none !important;
+  filter: none !important;
+}
+
+[data-ui-layout="modern"] .motion-sparks,
+[data-ui-layout="modern"] .motion-bar-fill::after {
+  display: none !important;
+}
+
+[data-ui-layout="modern"] .motion-card,
+[data-ui-layout="modern"] .motion-stagger > .motion-card {
+  animation: none !important;
+  translate: none !important;
+}


### PR DESCRIPTION
## Summary
- Classic keeps bar sheen/sparks (one provider at a time looks good).
- Modern dashboard: no looping bar lights, no card float, no overlay field — too many meters at once.
- Version **1.4.2** PATCH.

## Test plan
- [ ] Classic: bar light + bubbles still run
- [ ] Modern: meters are static; no aurora/orbs overlay
- [ ] Reduce animations still kills remaining FX
- [ ] Footer shows **1.4.2** after this ships


Made with [Cursor](https://cursor.com)