### PR TITLE
fix: tray style switching and Classic vs Modern logo pick

### DIFF
--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -1,5 +1,9 @@
 # Breadcrumbs
 
+## 2026-09-02
+
+- Tray readout (provider + meter, portal to `document.body`) + Classic vs Modern tray provider pick + mid-fill style previews. Lab Gemini Apps / Grok.com stay off this branch.
+
 ## 2026-08-28
 
 - Port OpenUsage **v0.7.10** → CrossUsage **1.4.3** on `feat/port-openusage-0.7.10`. Pricing supplement 2026-08-26; Cursor Grok Bot; Antigravity/Grok local spend; Claude spend-without-OAuth + Fable + sub-1% countdown; Copilot org credits; OpenRouter key window. Tracker: [PORT-0.7.10.md](./PORT-0.7.10.md).

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-- Tray readout (provider + meter, portal to `document.body`) + Classic vs Modern tray provider pick + mid-fill style previews. Lab Gemini Apps / Grok.com stay off this branch.
+- Tray readout (provider + meter, portal to `document.body`) + Classic vs Modern tray provider pick + mid-fill style previews. Lab Gemini Apps / Grok.com stay off this branch. Apply keeps other `trayLines` meters; Modern pin-sync does not clobber tray focus.
 
 ## 2026-08-28
 

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-- Tray readout (provider + meter, portal to `document.body`) + Classic vs Modern tray provider pick + mid-fill style previews. Lab Gemini Apps / Grok.com stay off this branch. Apply keeps other `trayLines` meters; Modern pin-sync does not clobber tray focus.
+- Tray readout (provider + meter, portal to `document.body`) + Classic vs Modern tray provider pick + mid-fill style previews. Lab Gemini Apps / Grok.com stay off this branch. Apply keeps other `trayLines` meters; Modern pin-sync does not clobber tray focus. Confirming an already-pinned only meter does not `unshift` it (other providers stay put).
 
 ## 2026-08-28
 

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -1,5 +1,11 @@
 # Choices
 
+## 2026-09-02
+
+- **Tray provider pick:** Classic follows the open sidebar provider. Modern may use pin focus / first pinned. Do not apply Modern pin focus on Classic (it froze the logo on one plugin).
+- **Tray readout dialog:** Logo+% / fill / pie / all-logos open a body-portaled picker when more than one enabled plugin or meter can drive the icon. Battery bars apply immediately. Style previews use a mid fill (`0.62`) so they are not all full at 90% remaining.
+- **Full-color tray logos:** SVGs without `currentColor` (and rasters) render as `<img>`, not a CSS mask.
+
 ## 2026-08-28
 
 - **No file line-count budget** (AGENTS.md). Do not split or drop code to stay under a LOC cap.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -3,7 +3,7 @@
 ## 2026-09-02
 
 - **Tray provider pick:** Classic follows the open sidebar provider. Modern may use pin focus / first pinned. Do not apply Modern pin focus on Classic (it froze the logo on one plugin).
-- **Tray readout dialog:** Logo+% / fill / pie / all-logos open a body-portaled picker when more than one enabled plugin or meter can drive the icon. Battery bars apply immediately. Style previews use a mid fill (`0.62`) so they are not all full at 90% remaining.
+- **Tray readout dialog:** Logo+% / fill / pie / all-logos open a body-portaled picker when more than one enabled plugin or meter can drive the icon. Battery bars apply immediately. Style previews use a mid fill (`0.62`) so they are not all full at 90% remaining. Apply promotes the picked meter to the front of existing `trayLines` (does not replace the list). Unset `trayLines` stay unset when the pick is already the default so dashboard/detail keep showing every metric. Modern pins + `trayFocusProviderId` take the pick; pin-sync from `trayLines` does not overwrite them after init.
 - **Full-color tray logos:** SVGs without `currentColor` (and rasters) render as `<img>`, not a CSS mask.
 
 ## 2026-08-28

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -3,7 +3,7 @@
 ## 2026-09-02
 
 - **Tray provider pick:** Classic follows the open sidebar provider. Modern may use pin focus / first pinned. Do not apply Modern pin focus on Classic (it froze the logo on one plugin).
-- **Tray readout dialog:** Logo+% / fill / pie / all-logos open a body-portaled picker when more than one enabled plugin or meter can drive the icon. Battery bars apply immediately. Style previews use a mid fill (`0.62`) so they are not all full at 90% remaining. Apply promotes the picked meter to the front of existing `trayLines` (does not replace the list). Unset `trayLines` stay unset when the pick is already the default so dashboard/detail keep showing every metric. Modern pins + `trayFocusProviderId` take the pick; pin-sync from `trayLines` does not overwrite them after init.
+- **Tray readout dialog:** Logo+% / fill / pie / all-logos open a body-portaled picker when more than one enabled plugin or meter can drive the icon. Battery bars apply immediately. Style previews use a mid fill (`0.62`) so they are not all full at 90% remaining. Apply promotes the picked meter to the front of existing `trayLines` (does not replace the list). Unset `trayLines` stay unset when the pick is already the default so dashboard/detail keep showing every metric. Modern pins + `trayFocusProviderId` take the pick; pin-sync from `trayLines` does not overwrite them after init. An already-pinned only meter stays at its index (sibling pins still move to the front of that provider group).
 - **Full-color tray logos:** SVGs without `currentColor` (and rasters) render as `<img>`, not a CSS mask.
 
 ## 2026-08-28

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,7 +300,7 @@ function App() {
     handleReorder,
     handleToggle,
     handleTrayLineToggle,
-    handleSetCursorTrayMetricForAllAccounts,
+    handleSetTrayReadout,
     handleDashboardMetricToggle,
     handleProviderDashboardMetrics,
   } = useSettingsPluginActions({
@@ -691,7 +691,7 @@ function App() {
       onUsageSpikeAlertThresholdPctChange: handleUsageSpikeAlertThresholdPctChange,
       onUIScaleChange: handleUIScaleChange,
       onShowAccountIdentityChange: handleShowAccountIdentityChange,
-      onSetCursorTrayMetricForAllAccounts: handleSetCursorTrayMetricForAllAccounts,
+      onSetTrayReadout: handleSetTrayReadout,
       cursorRequestsLineAvailable,
     },
   }

--- a/src/components/app/app-content.test.tsx
+++ b/src/components/app/app-content.test.tsx
@@ -89,7 +89,7 @@ function createProps(): AppContentProps {
     onUsageSpikeAlertThresholdPctChange: vi.fn(),
     onUIScaleChange: vi.fn(),
     onShowAccountIdentityChange: vi.fn(),
-    onSetCursorTrayMetricForAllAccounts: vi.fn(),
+    onSetTrayReadout: vi.fn(),
     cursorRequestsLineAvailable: null,
   }
 }

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -69,7 +69,7 @@ export type AppContentActionProps = {
   onUsageSpikeAlertThresholdPctChange: (value: import("@/lib/settings").UsageSpikeAlertThresholdPct) => void
   onUIScaleChange: (value: UIScale) => void
   onShowAccountIdentityChange: (value: boolean) => void
-  onSetCursorTrayMetricForAllAccounts: (lineLabel: string) => void
+  onSetTrayReadout: (pluginId: string, lineLabel: string) => void
   cursorRequestsLineAvailable: boolean | null
 }
 
@@ -115,7 +115,7 @@ export function AppContent({
   onUsageSpikeAlertThresholdPctChange,
   onUIScaleChange,
   onShowAccountIdentityChange,
-  onSetCursorTrayMetricForAllAccounts,
+  onSetTrayReadout,
   cursorRequestsLineAvailable,
   viewOverride,
 }: AppContentProps) {
@@ -263,7 +263,7 @@ export function AppContent({
         onUIScaleChange={onUIScaleChange}
         showAccountIdentity={showAccountIdentity}
         onShowAccountIdentityChange={onShowAccountIdentityChange}
-        onSetCursorTrayMetricForAllAccounts={onSetCursorTrayMetricForAllAccounts}
+        onSetTrayReadout={onSetTrayReadout}
         cursorRequestsLineAvailable={cursorRequestsLineAvailable}
         presentation={uiLayout === "modern" ? "modern" : "classic"}
       />

--- a/src/components/app/modern-shell.tsx
+++ b/src/components/app/modern-shell.tsx
@@ -117,6 +117,7 @@ export function ModernShell({
       hydrated: s.hydrated,
       ensureInitialized: s.ensureInitialized,
       setMetricOrder: s.setMetricOrder,
+      setTrayFocusProvider: s.setTrayFocusProvider,
       syncDescriptors: s.syncDescriptors,
       syncPinsFromTrayLines: s.syncPinsFromTrayLines,
     })),
@@ -352,6 +353,7 @@ export function ModernShell({
                   onRefreshPlugin={(pluginId) => {
                     appContentProps.onRetryPlugin(pluginId)
                   }}
+                  onFocusProvider={layout.setTrayFocusProvider}
                 />
               </div>
             ) : null}

--- a/src/components/modern/widget-grouped-list.tsx
+++ b/src/components/modern/widget-grouped-list.tsx
@@ -19,9 +19,10 @@ type WidgetGroupedListProps = {
   compact?: boolean
   className?: string
   onRefreshPlugin?: (pluginId: string) => void
+  onFocusProvider?: (pluginId: string) => void
 }
 
-export function WidgetGroupedList({ groups, compact, className, onRefreshPlugin }: WidgetGroupedListProps) {
+export function WidgetGroupedList({ groups, compact, className, onRefreshPlugin, onFocusProvider }: WidgetGroupedListProps) {
   if (groups.length === 0) {
     return (
       <div className="text-center text-muted-foreground py-8 text-sm">
@@ -38,6 +39,7 @@ export function WidgetGroupedList({ groups, compact, className, onRefreshPlugin 
           group={group}
           compact={compact}
           onRefreshPlugin={onRefreshPlugin}
+          onFocusProvider={onFocusProvider}
           index={index}
         />
       ))}
@@ -49,11 +51,13 @@ function ProviderCard({
   group,
   compact,
   onRefreshPlugin,
+  onFocusProvider,
   index = 0,
 }: {
   group: ProviderWidgetGroup
   compact?: boolean
   onRefreshPlugin?: (pluginId: string) => void
+  onFocusProvider?: (pluginId: string) => void
   index?: number
 }) {
   const bounded = group.metrics.filter((m) => m.bounded && m.kind === "progress")
@@ -72,7 +76,9 @@ function ProviderCard({
         className={cn(
           "flex items-center gap-2 px-3 border-b border-border/60",
           compact ? "py-1.5" : "py-2",
+          onFocusProvider ? "cursor-pointer hover:bg-muted/40" : "",
         )}
+        onClick={onFocusProvider ? () => onFocusProvider(group.pluginId) : undefined}
       >
         {group.iconUrl ? (
           <img src={group.iconUrl} alt="" className="h-4 w-4 shrink-0" />

--- a/src/components/provider-icon.tsx
+++ b/src/components/provider-icon.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils"
 import { getRelativeLuminance } from "@/lib/color"
-import { isRasterProviderIconUrl } from "@/lib/provider-icon-url"
+import { isFullColorProviderIconUrl } from "@/lib/provider-icon-url"
 
 function getMaskIconColor(brandColor: string | undefined, isDark: boolean): string {
   if (!brandColor) return "currentColor"
@@ -46,7 +46,7 @@ export function ProviderIcon({
     )
   }
 
-  if (isRasterProviderIconUrl(iconUrl)) {
+  if (isFullColorProviderIconUrl(iconUrl)) {
     return (
       <img
         src={iconUrl}

--- a/src/components/tray-readout-dialog.tsx
+++ b/src/components/tray-readout-dialog.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import {
+  defaultTrayReadoutLine,
+  enabledTrayReadoutPlugins,
+  type TrayReadoutPlugin,
+} from "@/lib/tray-readout-pick"
+import type { MenubarIconStyle } from "@/lib/settings"
+
+export type TrayReadoutDialogState = {
+  nextStyle: MenubarIconStyle
+  pluginId: string
+  lineLabel: string
+}
+
+type TrayReadoutDialogProps = {
+  dialog: TrayReadoutDialogState | null
+  plugins: TrayReadoutPlugin[]
+  onClose: () => void
+  onApply: (pluginId: string, lineLabel: string, nextStyle: MenubarIconStyle) => void
+}
+
+export function TrayReadoutDialog({ dialog, plugins, onClose, onApply }: TrayReadoutDialogProps) {
+  const enabled = enabledTrayReadoutPlugins(plugins)
+  const [pluginId, setPluginId] = useState(dialog?.pluginId ?? "")
+  const [lineLabel, setLineLabel] = useState(dialog?.lineLabel ?? "")
+
+  useEffect(() => {
+    if (!dialog) return
+    setPluginId(dialog.pluginId)
+    setLineLabel(dialog.lineLabel)
+  }, [dialog])
+
+  if (!dialog) return null
+
+  const selected = enabled.find((p) => p.id === pluginId) ?? enabled[0]
+  const lines = selected?.trayReadoutLabels ?? []
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="tray-readout-dialog-title"
+        className="max-w-md w-full max-h-[90vh] overflow-y-auto rounded-lg border border-border bg-card p-4 pt-5 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="tray-readout-dialog-title" className="text-base font-semibold text-foreground leading-normal">
+          Tray readout
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1 mb-3">
+          Pick which provider the tray icon follows, then which meter from that provider’s plugin.json.
+        </p>
+        {enabled.length > 1 ? (
+          <div className="mb-3">
+            <p className="text-xs font-medium text-muted-foreground mb-1">Provider</p>
+            <div
+              className="flex flex-col gap-1 max-h-36 overflow-y-auto"
+              role="radiogroup"
+              aria-label="Tray provider"
+            >
+              {enabled.map((plugin) => (
+                <button
+                  key={plugin.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={plugin.id === selected?.id}
+                  className={cn(
+                    "text-left text-sm rounded-md border px-2 py-1.5",
+                    plugin.id === selected?.id
+                      ? "border-primary bg-primary/10"
+                      : "border-border hover:bg-muted/50",
+                  )}
+                  onClick={() => {
+                    setPluginId(plugin.id)
+                    setLineLabel(defaultTrayReadoutLine(plugin))
+                  }}
+                >
+                  {plugin.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        <div className="flex flex-col gap-2" role="radiogroup" aria-label="Tray metric">
+          {lines.map((line) => (
+            <label key={line} className="flex items-center gap-2 text-sm cursor-pointer select-none">
+              <input
+                type="radio"
+                name="tray-readout-metric"
+                className="accent-primary"
+                checked={lineLabel === line}
+                onChange={() => setLineLabel(line)}
+              />
+              <span>{line}</span>
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2 mt-4">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!selected || !lineLabel}
+            onClick={() => {
+              if (!selected || !lineLabel) return
+              onApply(selected.id, lineLabel, dialog.nextStyle)
+            }}
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/hooks/app/use-settings-plugin-actions.test.ts
+++ b/src/hooks/app/use-settings-plugin-actions.test.ts
@@ -14,6 +14,9 @@ vi.mock("@/lib/settings", () => ({
 
 import type { PluginMeta } from "@/lib/plugin-types"
 import { useSettingsPluginActions } from "@/hooks/app/use-settings-plugin-actions"
+import { EMPTY_MODERN_LAYOUT } from "@/lib/modern-layout"
+import { metricId } from "@/lib/metric-id"
+import { useModernLayoutStore } from "@/stores/modern-layout-store"
 
 const codexMeta: PluginMeta = {
   id: "codex",
@@ -24,10 +27,27 @@ const codexMeta: PluginMeta = {
   primaryCandidates: ["Session", "Weekly"],
 }
 
+const antigravityMeta: PluginMeta = {
+  id: "antigravity",
+  name: "Antigravity",
+  iconUrl: "/antigravity.svg",
+  brandColor: "#000",
+  lines: [],
+  primaryCandidates: ["Session", "Weekly"],
+}
+
 describe("useSettingsPluginActions", () => {
   beforeEach(() => {
     savePluginSettingsMock.mockReset()
     savePluginSettingsMock.mockResolvedValue(undefined)
+    useModernLayoutStore.setState({
+      ...EMPTY_MODERN_LAYOUT,
+      hydrated: true,
+      pinLimitNotice: null,
+      initialized: true,
+      pinnedMetricIds: [metricId("claude", "Session")],
+      trayFocusProviderId: "claude",
+    })
   })
 
   it("reorders plugins and persists new order", () => {
@@ -394,5 +414,64 @@ describe("useSettingsPluginActions", () => {
       disabled: [],
       trayLines: { claude: ["Session"], antigravity: ["Weekly"] },
     })
+    expect(useModernLayoutStore.getState().trayFocusProviderId).toBe("antigravity")
+  })
+
+  it("promotes tray readout without dropping other meters", () => {
+    const setPluginSettings = vi.fn()
+    const { result } = renderHook(() =>
+      useSettingsPluginActions({
+        pluginSettings: {
+          order: ["antigravity"],
+          disabled: [],
+          trayLines: { antigravity: ["Session", "Weekly"] },
+        },
+        pluginsMeta: [antigravityMeta],
+        setPluginSettings,
+        setLoadingForPlugins: vi.fn(),
+        setErrorForPlugins: vi.fn(),
+        startBatch: vi.fn(),
+        scheduleTrayIconUpdate: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.handleSetTrayReadout("antigravity", "Weekly")
+    })
+
+    expect(setPluginSettings).toHaveBeenCalledWith({
+      order: ["antigravity"],
+      disabled: [],
+      trayLines: { antigravity: ["Weekly", "Session"] },
+    })
+  })
+
+  it("does not collapse unset trayLines when the pick is already the default", () => {
+    const setPluginSettings = vi.fn()
+    const { result } = renderHook(() =>
+      useSettingsPluginActions({
+        pluginSettings: {
+          order: ["antigravity"],
+          disabled: [],
+          trayLines: {},
+        },
+        pluginsMeta: [antigravityMeta],
+        setPluginSettings,
+        setLoadingForPlugins: vi.fn(),
+        setErrorForPlugins: vi.fn(),
+        startBatch: vi.fn(),
+        scheduleTrayIconUpdate: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.handleSetTrayReadout("antigravity", "Session")
+    })
+
+    expect(setPluginSettings).not.toHaveBeenCalled()
+    expect(useModernLayoutStore.getState().trayFocusProviderId).toBe("antigravity")
+    expect(useModernLayoutStore.getState().pinnedMetricIds[0]).toBe(
+      metricId("antigravity", "Session"),
+    )
   })
 })

--- a/src/hooks/app/use-settings-plugin-actions.test.ts
+++ b/src/hooks/app/use-settings-plugin-actions.test.ts
@@ -7,6 +7,7 @@ const { savePluginSettingsMock } = vi.hoisted(() => ({
 
 vi.mock("@/lib/settings", () => ({
   savePluginSettings: savePluginSettingsMock,
+  saveModernLayout: vi.fn().mockResolvedValue(undefined),
   getProviderInstanceMeta: (id: string, _settings: unknown, plugins: PluginMeta[]) =>
     plugins.find((plugin) => plugin.id === id) ?? null,
 }))
@@ -363,6 +364,35 @@ describe("useSettingsPluginActions", () => {
       order: ["codex"],
       disabled: [],
       trayLines: { codex: ["Session", "Weekly"] },
+    })
+  })
+
+  it("sets tray readout for one plugin and focuses it", () => {
+    const setPluginSettings = vi.fn()
+    const { result } = renderHook(() =>
+      useSettingsPluginActions({
+        pluginSettings: {
+          order: ["claude", "antigravity"],
+          disabled: [],
+          trayLines: { claude: ["Session"] },
+        },
+        pluginsMeta: [codexMeta],
+        setPluginSettings,
+        setLoadingForPlugins: vi.fn(),
+        setErrorForPlugins: vi.fn(),
+        startBatch: vi.fn(),
+        scheduleTrayIconUpdate: vi.fn(),
+      })
+    )
+
+    act(() => {
+      result.current.handleSetTrayReadout("antigravity", "Weekly")
+    })
+
+    expect(setPluginSettings).toHaveBeenCalledWith({
+      order: ["claude", "antigravity"],
+      disabled: [],
+      trayLines: { claude: ["Session"], antigravity: ["Weekly"] },
     })
   })
 })

--- a/src/hooks/app/use-settings-plugin-actions.ts
+++ b/src/hooks/app/use-settings-plugin-actions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/modern-layout"
 import { parseMetricId } from "@/lib/metric-id"
 import { getProviderInstanceMeta, savePluginSettings, type PluginSettings } from "@/lib/settings"
+import { useModernLayoutStore } from "@/stores/modern-layout-store"
 
 const TRAY_SETTINGS_DEBOUNCE_MS = 2000
 
@@ -143,28 +144,24 @@ export function useSettingsPluginActions({
     setPluginSettings,
   ])
 
-  const handleSetCursorTrayMetricForAllAccounts = useCallback(
-    (lineLabel: string) => {
+  const handleSetTrayReadout = useCallback(
+    (pluginId: string, lineLabel: string) => {
       if (!pluginSettings) return
-      const nextTrayLines = { ...pluginSettings.trayLines }
-      for (const id of pluginSettings.order) {
-        if (pluginSettings.disabled.includes(id)) continue
-        const meta = getProviderInstanceMeta(id, pluginSettings, pluginsMeta)
-        const base = meta?.baseProviderId ?? meta?.id
-        if (base !== "cursor") continue
-        nextTrayLines[id] = [lineLabel]
-      }
       const nextSettings: PluginSettings = {
         ...pluginSettings,
-        trayLines: nextTrayLines,
+        trayLines: {
+          ...pluginSettings.trayLines,
+          [pluginId]: [lineLabel],
+        },
       }
       setPluginSettings(nextSettings)
       scheduleTrayIconUpdate("settings", TRAY_SETTINGS_DEBOUNCE_MS)
+      useModernLayoutStore.getState().setTrayFocusProvider(pluginId)
       void savePluginSettings(nextSettings).catch((error) => {
-        console.error("Failed to save Cursor tray metric:", error)
+        console.error("Failed to save tray readout:", error)
       })
     },
-    [pluginSettings, pluginsMeta, scheduleTrayIconUpdate, setPluginSettings],
+    [pluginSettings, scheduleTrayIconUpdate, setPluginSettings],
   )
 
   const persistPluginSettings = useCallback(
@@ -213,7 +210,7 @@ export function useSettingsPluginActions({
     handleReorder,
     handleToggle,
     handleTrayLineToggle,
-    handleSetCursorTrayMetricForAllAccounts,
+    handleSetTrayReadout,
     handleDashboardMetricToggle,
     handleProviderDashboardMetrics,
   }

--- a/src/hooks/app/use-settings-plugin-actions.ts
+++ b/src/hooks/app/use-settings-plugin-actions.ts
@@ -6,6 +6,7 @@ import {
   applyProviderDashboardMetrics,
 } from "@/lib/modern-layout"
 import { parseMetricId } from "@/lib/metric-id"
+import { applyTrayReadoutLines } from "@/lib/tray-readout-pick"
 import { getProviderInstanceMeta, savePluginSettings, type PluginSettings } from "@/lib/settings"
 import { useModernLayoutStore } from "@/stores/modern-layout-store"
 
@@ -147,21 +148,39 @@ export function useSettingsPluginActions({
   const handleSetTrayReadout = useCallback(
     (pluginId: string, lineLabel: string) => {
       if (!pluginSettings) return
-      const nextSettings: PluginSettings = {
-        ...pluginSettings,
-        trayLines: {
-          ...pluginSettings.trayLines,
-          [pluginId]: [lineLabel],
-        },
+      const primaryCandidates =
+        getProviderInstanceMeta(pluginId, pluginSettings, pluginsMeta)?.primaryCandidates ?? []
+      const unsetFallback = getEffectiveTrayLines(pluginId, pluginSettings, primaryCandidates)
+      const nextLines = applyTrayReadoutLines(
+        pluginSettings.trayLines?.[pluginId],
+        lineLabel,
+        unsetFallback,
+      )
+      const prevLines = pluginSettings.trayLines?.[pluginId]
+      const trayLinesChanged =
+        nextLines !== undefined &&
+        (prevLines == null ||
+          prevLines.length !== nextLines.length ||
+          prevLines.some((label, i) => label !== nextLines[i]))
+
+      if (trayLinesChanged && nextLines) {
+        const nextSettings: PluginSettings = {
+          ...pluginSettings,
+          trayLines: {
+            ...pluginSettings.trayLines,
+            [pluginId]: nextLines,
+          },
+        }
+        setPluginSettings(nextSettings)
+        scheduleTrayIconUpdate("settings", TRAY_SETTINGS_DEBOUNCE_MS)
+        void savePluginSettings(nextSettings).catch((error) => {
+          console.error("Failed to save tray readout:", error)
+        })
       }
-      setPluginSettings(nextSettings)
-      scheduleTrayIconUpdate("settings", TRAY_SETTINGS_DEBOUNCE_MS)
-      useModernLayoutStore.getState().setTrayFocusProvider(pluginId)
-      void savePluginSettings(nextSettings).catch((error) => {
-        console.error("Failed to save tray readout:", error)
-      })
+
+      useModernLayoutStore.getState().applyTrayReadout(pluginId, lineLabel)
     },
-    [pluginSettings, scheduleTrayIconUpdate, setPluginSettings],
+    [pluginSettings, pluginsMeta, scheduleTrayIconUpdate, setPluginSettings],
   )
 
   const persistPluginSettings = useCallback(

--- a/src/hooks/app/use-settings-plugin-list.test.ts
+++ b/src/hooks/app/use-settings-plugin-list.test.ts
@@ -14,7 +14,11 @@ function createPluginMeta(
     name,
     iconUrl: `/${id}.svg`,
     brandColor: "#000000",
-    lines: [],
+    lines: primaryCandidates.map((label) => ({
+      type: "progress" as const,
+      label,
+      scope: "overview" as const,
+    })),
     primaryCandidates,
   }
 }
@@ -37,8 +41,8 @@ describe("useSettingsPluginList", () => {
     )
 
     expect(result.current).toEqual([
-      { id: "codex", baseProviderId: "codex", name: "Codex", enabled: true, primaryCandidates: [], trayLines: [] },
-      { id: "cursor", baseProviderId: "cursor", name: "Cursor", enabled: false, primaryCandidates: [], trayLines: [] },
+      { id: "codex", baseProviderId: "codex", name: "Codex", enabled: true, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
+      { id: "cursor", baseProviderId: "cursor", name: "Cursor", enabled: false, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
     ])
   })
 
@@ -66,6 +70,7 @@ describe("useSettingsPluginList", () => {
         name: "Claude",
         enabled: true,
         primaryCandidates: ["Usage"],
+        trayReadoutLabels: ["Usage"],
         trayLines: ["Usage"],
       },
       {
@@ -75,6 +80,7 @@ describe("useSettingsPluginList", () => {
         name: "Claude (Work)",
         enabled: true,
         primaryCandidates: ["Usage"],
+        trayReadoutLabels: ["Usage"],
         trayLines: ["Usage"],
       },
     ])
@@ -101,9 +107,46 @@ describe("useSettingsPluginList", () => {
         name: "Codex",
         enabled: true,
         primaryCandidates: ["Session", "Weekly"],
+        trayReadoutLabels: ["Session", "Weekly"],
         trayLines: ["Session"],
       },
     ])
+  })
+
+  it("lists every plugin.json progress line even without primaryOrder", () => {
+    const pluginSettings: PluginSettings = {
+      order: ["cursor"],
+      disabled: [],
+    }
+
+    const { result } = renderHook(() =>
+      useSettingsPluginList({
+        pluginSettings,
+        pluginsMeta: [
+          {
+            id: "cursor",
+            name: "Cursor",
+            iconUrl: "/cursor.svg",
+            iconFilePath: "",
+            brandColor: "#000",
+            lines: [
+              { type: "progress", label: "Credits", scope: "overview" },
+              { type: "progress", label: "Total usage", scope: "overview" },
+              { type: "progress", label: "Cursor Models", scope: "detail" },
+              { type: "text", label: "Today", scope: "detail" },
+            ],
+            primaryCandidates: ["Total usage", "Credits"],
+          },
+        ],
+      })
+    )
+
+    expect(result.current[0]?.trayReadoutLabels).toEqual([
+      "Credits",
+      "Total usage",
+      "Cursor Models",
+    ])
+    expect(result.current[0]?.primaryCandidates).toEqual(["Total usage", "Credits"])
   })
 
   it("returns empty list when settings are not loaded", () => {

--- a/src/hooks/app/use-settings-plugin-list.ts
+++ b/src/hooks/app/use-settings-plugin-list.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import type { PluginMeta } from "@/lib/plugin-types"
 import { getProviderInstanceMeta, type PluginSettings } from "@/lib/settings"
 import { getEffectiveTrayLines } from "@/lib/tray-line-selection"
+import { trayReadoutLabelsFromManifest } from "@/lib/tray-readout-pick"
 
 export type SettingsPluginState = {
   id: string
@@ -10,6 +11,7 @@ export type SettingsPluginState = {
   name: string
   enabled: boolean
   primaryCandidates: string[]
+  trayReadoutLabels: string[]
   trayLines: string[]
 }
 
@@ -27,6 +29,7 @@ export function useSettingsPluginList({ pluginSettings, pluginsMeta }: UseSettin
         const meta = getProviderInstanceMeta(id, pluginSettings, pluginsMeta)
         if (!meta) return []
         const primaryCandidates = meta.primaryCandidates || []
+        const trayReadoutLabels = trayReadoutLabelsFromManifest(meta.lines ?? [])
         const trayLines = getEffectiveTrayLines(
           id,
           pluginSettings,
@@ -39,6 +42,7 @@ export function useSettingsPluginList({ pluginSettings, pluginsMeta }: UseSettin
           name: meta.name,
           enabled: !pluginSettings.disabled.includes(id),
           primaryCandidates,
+          trayReadoutLabels,
           trayLines,
         }]
       })

--- a/src/hooks/app/use-tray-icon.ts
+++ b/src/hooks/app/use-tray-icon.ts
@@ -12,6 +12,7 @@ import { getTrayForegroundHex, renderTrayBarsIcon, type TrayProviderIcon } from 
 import { getTrayIconSizePx } from "@/lib/tray-icon-size"
 import { formatTrayIssuesAppendage } from "@/lib/tray-health"
 import type { TrayPrimaryBar } from "@/lib/tray-primary-progress"
+import { pickTrayProviderId } from "@/lib/tray-provider-id"
 import { formatTrayItemCaption, formatTrayTooltip } from "@/lib/tray-tooltip"
 import { formatTopTrayInsightLine } from "@/lib/usage-insights"
 import { useAppPreferencesStore } from "@/stores/app-preferences-store"
@@ -291,21 +292,15 @@ export function useTrayIcon({
       })()
 
       const focusFromLayout = trayFocusProviderIdRef.current
-      let trayProviderId: string | null = null
-      if (focusFromLayout && enabledPluginIds.includes(focusFromLayout)) {
-        trayProviderId = focusFromLayout
-      } else if (activeProviderId && enabledPluginIds.includes(activeProviderId)) {
-        trayProviderId = activeProviderId
-      } else if (
-        lastTrayProviderIdRef.current &&
-        enabledPluginIds.includes(lastTrayProviderIdRef.current)
-      ) {
-        trayProviderId = lastTrayProviderIdRef.current
-      } else if (firstPinnedProviderId) {
-        trayProviderId = firstPinnedProviderId
-      } else {
-        trayProviderId = enabledPluginIds[0] ?? null
-      }
+      const trayProviderId = pickTrayProviderId({
+        uiLayout: uiLayoutRef.current,
+        enabledPluginIds,
+        activeProviderId,
+        trayFocusProviderId: focusFromLayout,
+        lastTrayProviderId: lastTrayProviderIdRef.current,
+        firstPinnedProviderId,
+      })
+      if (trayProviderId) lastTrayProviderIdRef.current = trayProviderId
 
       const barsForPreview = resolveTrayBarsForLayout({
         uiLayout: uiLayoutRef.current,

--- a/src/lib/provider-icon-url.test.ts
+++ b/src/lib/provider-icon-url.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it } from "vitest"
-import { isRasterProviderIconUrl } from "@/lib/provider-icon-url"
+import { isFullColorProviderIconUrl, isRasterProviderIconUrl } from "@/lib/provider-icon-url"
 
 describe("isRasterProviderIconUrl", () => {
   it("detects png data urls", () => {
     expect(isRasterProviderIconUrl("data:image/png;base64,abc")).toBe(true)
   })
 
-  it("treats svg data urls as mask icons", () => {
+  it("treats svg data urls as not raster", () => {
     expect(isRasterProviderIconUrl("data:image/svg+xml;base64,abc")).toBe(false)
+  })
+})
+
+describe("isFullColorProviderIconUrl", () => {
+  it("treats png data urls as full-color", () => {
+    expect(isFullColorProviderIconUrl("data:image/png;base64,abc")).toBe(true)
+  })
+
+  it("treats currentColor svg data urls as mask icons", () => {
+    const svg = encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><path fill="currentColor" d="M0 0h10v10H0z"/></svg>',
+    )
+    expect(isFullColorProviderIconUrl(`data:image/svg+xml,${svg}`)).toBe(false)
+  })
+
+  it("treats gradient svg data urls as full-color", () => {
+    const svg = encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><defs><linearGradient id="g"><stop stop-color="#3186FF"/></linearGradient></defs><path fill="url(#g)" d="M0 0h10v10H0z"/></svg>',
+    )
+    expect(isFullColorProviderIconUrl(`data:image/svg+xml,${svg}`)).toBe(true)
   })
 })

--- a/src/lib/provider-icon-url.ts
+++ b/src/lib/provider-icon-url.ts
@@ -4,3 +4,28 @@ export function isRasterProviderIconUrl(iconUrl: string | undefined): boolean {
   const trimmed = iconUrl.trim()
   return /^data:image\/(png|jpe?g|webp);base64,/i.test(trimmed)
 }
+
+function decodeSvgDataUrl(url: string): string | null {
+  const match = url.match(/^data:image\/svg\+xml(?:;charset=[^;,]+)?(;base64)?,(.*)$/i)
+  if (!match) return null
+  const payload = match[2]
+  try {
+    if (match[1]) {
+      if (typeof atob !== "function") return null
+      return atob(payload)
+    }
+    return decodeURIComponent(payload)
+  } catch {
+    return null
+  }
+}
+
+/** Raster logos, or SVGs that are not currentColor-tinted (e.g. Gemini 2025 gradient). */
+export function isFullColorProviderIconUrl(iconUrl: string | undefined): boolean {
+  if (!iconUrl) return false
+  const trimmed = iconUrl.trim()
+  if (isRasterProviderIconUrl(trimmed)) return true
+  const svg = decodeSvgDataUrl(trimmed)
+  if (!svg) return false
+  return !/currentColor/i.test(svg)
+}

--- a/src/lib/tray-bars-icon.test.ts
+++ b/src/lib/tray-bars-icon.test.ts
@@ -223,6 +223,21 @@ describe("tray-bars-icon", () => {
     expect(svg).not.toContain("<image ")
   })
 
+  it("embeds full-color svg provider icons as images so gradients stay intact", () => {
+    const icon = encodeURIComponent(
+      '<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="g"><stop stop-color="#3186FF"/></linearGradient></defs><path d="M0 0h10v10H0z" fill="url(#g)"/></svg>'
+    )
+    const svg = makeTrayBarsSvg({
+      sizePx: 30,
+      style: "provider",
+      providerIconUrl: `data:image/svg+xml,${icon}`,
+      foregroundHex: "#ffffff",
+      gridCells: [{ text: "76%" }],
+    })
+    expect(svg).toContain("<image ")
+    expect(svg).not.toContain('fill="currentColor"')
+  })
+
   it("uses provider brand color for currentColor provider tray icons", () => {
     const icon = encodeURIComponent(
       '<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h10v10H0z" fill="currentColor"/></svg>'

--- a/src/lib/tray-bars-icon.ts
+++ b/src/lib/tray-bars-icon.ts
@@ -83,7 +83,10 @@ function providerIconMarkup(args: {
   const drawY = y - bleed
   const drawSize = size + bleed * 2
   const svgText = href.length > 0 ? decodeSvgDataUrl(href) : null
-  const inlineSvg = svgText ? inlineSvgImage({ svgText, x: drawX, y: drawY, size: drawSize, color }) : null
+  const inlineSvg =
+    svgText && /currentColor/i.test(svgText)
+      ? inlineSvgImage({ svgText, x: drawX, y: drawY, size: drawSize, color })
+      : null
   const content = inlineSvg
     ? inlineSvg
     : href.length > 0

--- a/src/lib/tray-provider-id.test.ts
+++ b/src/lib/tray-provider-id.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import { pickTrayProviderId } from "@/lib/tray-provider-id"
+
+const enabled = ["claude", "cursor", "codex"]
+
+describe("pickTrayProviderId", () => {
+  it("classic follows the open sidebar provider", () => {
+    expect(
+      pickTrayProviderId({
+        uiLayout: "classic",
+        enabledPluginIds: enabled,
+        activeProviderId: "cursor",
+        trayFocusProviderId: "claude",
+        lastTrayProviderId: "claude",
+        firstPinnedProviderId: "claude",
+      }),
+    ).toBe("cursor")
+  })
+
+  it("classic ignores pin focus on home and uses last viewed", () => {
+    expect(
+      pickTrayProviderId({
+        uiLayout: "classic",
+        enabledPluginIds: [...enabled, "antigravity"],
+        activeProviderId: null,
+        trayFocusProviderId: "antigravity",
+        lastTrayProviderId: "cursor",
+        firstPinnedProviderId: "claude",
+      }),
+    ).toBe("cursor")
+  })
+
+  it("falls back to last viewed when tray focus is missing", () => {
+    expect(
+      pickTrayProviderId({
+        uiLayout: "classic",
+        enabledPluginIds: enabled,
+        activeProviderId: null,
+        trayFocusProviderId: null,
+        lastTrayProviderId: "cursor",
+        firstPinnedProviderId: "claude",
+      }),
+    ).toBe("cursor")
+  })
+
+  it("modern dashboard with no open provider uses tray focus", () => {
+    expect(
+      pickTrayProviderId({
+        uiLayout: "modern",
+        enabledPluginIds: enabled,
+        activeProviderId: null,
+        trayFocusProviderId: "claude",
+        lastTrayProviderId: "codex",
+        firstPinnedProviderId: "cursor",
+      }),
+    ).toBe("claude")
+  })
+
+  it("falls back to the open provider when tray focus is missing", () => {
+    expect(
+      pickTrayProviderId({
+        uiLayout: "modern",
+        enabledPluginIds: enabled,
+        activeProviderId: "cursor",
+        trayFocusProviderId: null,
+        lastTrayProviderId: null,
+        firstPinnedProviderId: null,
+      }),
+    ).toBe("cursor")
+  })
+
+  it("modern uses first pinned when nothing else is selected", () => {
+    expect(
+      pickTrayProviderId({
+        uiLayout: "modern",
+        enabledPluginIds: enabled,
+        activeProviderId: null,
+        trayFocusProviderId: null,
+        lastTrayProviderId: null,
+        firstPinnedProviderId: "cursor",
+      }),
+    ).toBe("cursor")
+  })
+})

--- a/src/lib/tray-provider-id.ts
+++ b/src/lib/tray-provider-id.ts
@@ -10,7 +10,7 @@ export function pickTrayProviderId(args: {
 }): string | null {
   const enabled = args.enabledPluginIds
   const isEnabled = (id: string | null | undefined): id is string =>
-    Boolean(id) && enabled.includes(id)
+    typeof id === "string" && enabled.includes(id)
 
   // Classic follows the sidebar. Modern pin focus must not freeze Classic on one logo.
   if (args.uiLayout === "modern" && isEnabled(args.trayFocusProviderId)) {

--- a/src/lib/tray-provider-id.ts
+++ b/src/lib/tray-provider-id.ts
@@ -1,0 +1,25 @@
+import type { UILayout } from "@/lib/settings"
+
+export function pickTrayProviderId(args: {
+  uiLayout: UILayout
+  enabledPluginIds: string[]
+  activeProviderId: string | null
+  trayFocusProviderId: string | null
+  lastTrayProviderId: string | null
+  firstPinnedProviderId: string | null
+}): string | null {
+  const enabled = args.enabledPluginIds
+  const isEnabled = (id: string | null | undefined): id is string =>
+    Boolean(id) && enabled.includes(id)
+
+  // Classic follows the sidebar. Modern pin focus must not freeze Classic on one logo.
+  if (args.uiLayout === "modern" && isEnabled(args.trayFocusProviderId)) {
+    return args.trayFocusProviderId
+  }
+  if (isEnabled(args.activeProviderId)) return args.activeProviderId
+  if (isEnabled(args.lastTrayProviderId)) return args.lastTrayProviderId
+  if (args.uiLayout === "modern" && isEnabled(args.firstPinnedProviderId)) {
+    return args.firstPinnedProviderId
+  }
+  return enabled[0] ?? null
+}

--- a/src/lib/tray-readout-pick.test.ts
+++ b/src/lib/tray-readout-pick.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  defaultTrayReadoutLine,
+  defaultTrayReadoutPluginId,
+  shouldOpenTrayReadoutDialog,
+  trayReadoutLabelsFromManifest,
+} from "@/lib/tray-readout-pick"
+
+const antigravity = {
+  id: "antigravity",
+  name: "Antigravity",
+  enabled: true,
+  trayReadoutLabels: ["Session", "Weekly"],
+  trayLines: ["Session"],
+}
+
+const claude = {
+  id: "claude",
+  name: "Claude",
+  enabled: true,
+  trayReadoutLabels: ["Session"],
+  trayLines: ["Session"],
+}
+
+describe("trayReadoutLabelsFromManifest", () => {
+  it("keeps plugin.json progress lines in file order and skips text/charts", () => {
+    expect(
+      trayReadoutLabelsFromManifest([
+        { type: "progress", label: "Credits", scope: "overview" },
+        { type: "progress", label: "Total usage", scope: "overview" },
+        { type: "progress", label: "Cursor Models", scope: "detail" },
+        { type: "text", label: "Today", scope: "detail" },
+        { type: "barChart", label: "Usage Trend", scope: "detail" },
+        { type: "progress", label: "On-demand", scope: "detail" },
+      ]),
+    ).toEqual(["Credits", "Total usage", "Cursor Models", "On-demand"])
+  })
+})
+
+describe("shouldOpenTrayReadoutDialog", () => {
+  it("skips battery bars", () => {
+    expect(shouldOpenTrayReadoutDialog("bars", [antigravity, claude])).toBe(false)
+  })
+
+  it("skips a single plugin with one meter", () => {
+    expect(shouldOpenTrayReadoutDialog("donut", [claude])).toBe(false)
+  })
+
+  it("opens for one plugin with several meters", () => {
+    expect(shouldOpenTrayReadoutDialog("donut", [antigravity])).toBe(true)
+  })
+
+  it("opens when several plugins can drive the icon", () => {
+    expect(shouldOpenTrayReadoutDialog("provider", [claude, antigravity])).toBe(true)
+  })
+})
+
+describe("defaults", () => {
+  it("prefers the current tray plugin when still enabled", () => {
+    expect(defaultTrayReadoutPluginId([claude, antigravity], "antigravity")).toBe("antigravity")
+  })
+
+  it("uses the plugin's current tray line when it is still a candidate", () => {
+    expect(defaultTrayReadoutLine({ ...antigravity, trayLines: ["Weekly"] })).toBe("Weekly")
+  })
+})

--- a/src/lib/tray-readout-pick.test.ts
+++ b/src/lib/tray-readout-pick.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  applyTrayReadoutLines,
   defaultTrayReadoutLine,
   defaultTrayReadoutPluginId,
   shouldOpenTrayReadoutDialog,
@@ -63,5 +64,23 @@ describe("defaults", () => {
 
   it("uses the plugin's current tray line when it is still a candidate", () => {
     expect(defaultTrayReadoutLine({ ...antigravity, trayLines: ["Weekly"] })).toBe("Weekly")
+  })
+})
+
+describe("applyTrayReadoutLines", () => {
+  it("promotes the pick without dropping other meters", () => {
+    expect(applyTrayReadoutLines(["Session", "Weekly"], "Weekly")).toEqual(["Weekly", "Session"])
+  })
+
+  it("leaves unset trayLines unset when the pick is already the default", () => {
+    expect(applyTrayReadoutLines(undefined, "Session", ["Session"])).toBeUndefined()
+  })
+
+  it("prepends onto the default when unset and the pick differs", () => {
+    expect(applyTrayReadoutLines(undefined, "Weekly", ["Session"])).toEqual(["Weekly", "Session"])
+  })
+
+  it("replaces the none sentinel with the pick", () => {
+    expect(applyTrayReadoutLines(["__NONE__"], "Weekly")).toEqual(["Weekly"])
   })
 })

--- a/src/lib/tray-readout-pick.ts
+++ b/src/lib/tray-readout-pick.ts
@@ -1,0 +1,63 @@
+import type { ManifestLine } from "@/lib/plugin-types"
+import type { MenubarIconStyle } from "@/lib/settings"
+
+export const TRAY_STYLES_NEED_READOUT_PICK: ReadonlySet<MenubarIconStyle> = new Set([
+  "provider",
+  "donut",
+  "logoBar",
+  "logoGrid",
+])
+
+export type TrayReadoutPlugin = {
+  id: string
+  name: string
+  enabled: boolean
+  trayReadoutLabels: string[]
+  trayLines: string[]
+}
+
+/** Progress lines from plugin.json, in file order. Text / badge / charts are not tray meters. */
+export function trayReadoutLabelsFromManifest(lines: ManifestLine[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const line of lines) {
+    if (line.type !== "progress") continue
+    if (seen.has(line.label)) continue
+    seen.add(line.label)
+    out.push(line.label)
+  }
+  return out
+}
+
+export function enabledTrayReadoutPlugins<T extends TrayReadoutPlugin>(plugins: T[]): T[] {
+  return plugins.filter((p) => p.enabled && p.trayReadoutLabels.length > 0)
+}
+
+/** Open the picker when more than one plugin can drive the icon, or one plugin has several meters. */
+export function shouldOpenTrayReadoutDialog(
+  style: MenubarIconStyle,
+  plugins: TrayReadoutPlugin[],
+): boolean {
+  if (!TRAY_STYLES_NEED_READOUT_PICK.has(style)) return false
+  const enabled = enabledTrayReadoutPlugins(plugins)
+  if (enabled.length === 0) return false
+  if (enabled.length > 1) return true
+  return enabled[0].trayReadoutLabels.length > 1
+}
+
+export function defaultTrayReadoutPluginId(
+  plugins: TrayReadoutPlugin[],
+  preferredId?: string | null,
+): string | null {
+  const enabled = enabledTrayReadoutPlugins(plugins)
+  if (preferredId && enabled.some((p) => p.id === preferredId)) return preferredId
+  return enabled[0]?.id ?? null
+}
+
+export function defaultTrayReadoutLine(plugin: TrayReadoutPlugin | undefined): string {
+  if (!plugin) return ""
+  const labels = plugin.trayReadoutLabels
+  const current = plugin.trayLines[0]
+  if (current && labels.includes(current)) return current
+  return labels[0] ?? ""
+}

--- a/src/lib/tray-readout-pick.ts
+++ b/src/lib/tray-readout-pick.ts
@@ -61,3 +61,21 @@ export function defaultTrayReadoutLine(plugin: TrayReadoutPlugin | undefined): s
   if (current && labels.includes(current)) return current
   return labels[0] ?? ""
 }
+
+/**
+ * Put `lineLabel` first without dropping other meters.
+ * Returns undefined when trayLines is unset and the pick is already the default
+ * (leave unset so Classic detail / Modern dashboard keep showing every metric).
+ */
+export function applyTrayReadoutLines(
+  prev: string[] | undefined,
+  lineLabel: string,
+  unsetFallback: string[] = [],
+): string[] | undefined {
+  if (prev == null || prev.length === 0) {
+    if (unsetFallback[0] === lineLabel) return undefined
+    return [lineLabel, ...unsetFallback.filter((l) => l !== lineLabel)]
+  }
+  if (prev[0] === "__NONE__") return [lineLabel]
+  return [lineLabel, ...prev.filter((l) => l !== "__NONE__" && l !== lineLabel)]
+}

--- a/src/pages/settings.test.tsx
+++ b/src/pages/settings.test.tsx
@@ -92,7 +92,7 @@ function renderSettings(props: React.ComponentProps<typeof SettingsPage>) {
 }
 
 const defaultProps = {
-  plugins: [{ id: "a", baseProviderId: "a", name: "Alpha", enabled: true, primaryCandidates: [], trayLines: [] }],
+  plugins: [{ id: "a", baseProviderId: "a", name: "Alpha", enabled: true, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] }],
   onReorder: vi.fn(),
   onToggle: vi.fn(),
   onTrayLineToggle: vi.fn(),
@@ -152,7 +152,7 @@ const defaultProps = {
   showAccountIdentity: true,
   onShowAccountIdentityChange: vi.fn(),
   cursorRequestsLineAvailable: null,
-  onSetCursorTrayMetricForAllAccounts: vi.fn(),
+  onSetTrayReadout: vi.fn(),
 }
 
 afterEach(() => {
@@ -174,7 +174,7 @@ describe("SettingsPage", () => {
     renderSettings({
       ...defaultProps,
       plugins: [
-          { id: "b", baseProviderId: "b", name: "Beta", enabled: false, primaryCandidates: [], trayLines: [] },
+          { id: "b", baseProviderId: "b", name: "Beta", enabled: false, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
         ],
       onToggle,
     })
@@ -188,8 +188,8 @@ describe("SettingsPage", () => {
     renderSettings({
       ...defaultProps,
       plugins: [
-          { id: "a", baseProviderId: "a", name: "Alpha", enabled: true, primaryCandidates: [], trayLines: [] },
-          { id: "b", baseProviderId: "b", name: "Beta", enabled: true, primaryCandidates: [], trayLines: [] },
+          { id: "a", baseProviderId: "a", name: "Alpha", enabled: true, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
+          { id: "b", baseProviderId: "b", name: "Beta", enabled: true, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
         ],
       onReorder,
     })
@@ -217,7 +217,7 @@ describe("SettingsPage", () => {
     renderSettings({
       ...defaultProps,
       plugins: [
-          { id: "claude", baseProviderId: "claude", name: "Claude", enabled: true, primaryCandidates: [], trayLines: [] },
+          { id: "claude", baseProviderId: "claude", name: "Claude", enabled: true, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
           {
             id: "claude:work",
             baseProviderId: "claude",
@@ -225,6 +225,7 @@ describe("SettingsPage", () => {
             name: "Claude (Work)",
             enabled: true,
             primaryCandidates: [],
+            trayReadoutLabels: [],
             trayLines: [],
           },
         ],
@@ -273,7 +274,7 @@ describe("SettingsPage", () => {
     renderSettings({
       ...defaultProps,
       plugins: [
-          { id: "claude", baseProviderId: "claude", name: "Claude", enabled: true, primaryCandidates: [], trayLines: [] },
+          { id: "claude", baseProviderId: "claude", name: "Claude", enabled: true, primaryCandidates: [], trayReadoutLabels: [], trayLines: [] },
         ],
     })
     await user.click(screen.getByRole("button", { name: "Add account" }))
@@ -412,31 +413,48 @@ describe("SettingsPage", () => {
     expect(onMenubarIconStyleChange).toHaveBeenCalledWith("donut")
   })
 
-  it("opens Cursor tray metric dialog when choosing Pie with Cursor enabled", async () => {
+  it("opens tray readout dialog with per-plugin meters", async () => {
     const onMenubarIconStyleChange = vi.fn()
-    const onSetCursorTrayMetricForAllAccounts = vi.fn()
+    const onSetTrayReadout = vi.fn()
     const user = userEvent.setup()
     renderSettings({
       ...defaultProps,
       menubarIconStyle: "bars",
       plugins: [
-          {
-            id: "cursor",
-            baseProviderId: "cursor",
-            name: "Cursor",
-            enabled: true,
-            primaryCandidates: ["Total usage"],
-            trayLines: ["Total usage"],
-          },
-        ],
+        {
+          id: "claude",
+          baseProviderId: "claude",
+          name: "Claude",
+          enabled: true,
+          primaryCandidates: ["Session"],
+          trayReadoutLabels: ["Session", "Weekly", "Fable", "Sonnet", "Claude Design", "Extra usage spent"],
+          trayLines: ["Session"],
+        },
+        {
+          id: "antigravity",
+          baseProviderId: "antigravity",
+          name: "Antigravity",
+          enabled: true,
+          primaryCandidates: ["Session", "Weekly"],
+          trayReadoutLabels: [
+            "Session",
+            "Weekly",
+            "Session — Claude and GPT Models",
+            "Weekly — Claude and GPT Models",
+          ],
+          trayLines: ["Session"],
+        },
+      ],
       onMenubarIconStyleChange,
-      onSetCursorTrayMetricForAllAccounts,
+      onSetTrayReadout,
     })
     await user.click(screen.getByRole("radio", { name: "Pie chart" }))
-    expect(screen.getByRole("dialog", { name: "Cursor tray readout" })).toBeInTheDocument()
-    await user.click(screen.getByRole("radio", { name: "Credits" }))
+    expect(screen.getByRole("dialog", { name: "Tray readout" })).toBeInTheDocument()
+    await user.click(screen.getByRole("radio", { name: "Antigravity" }))
+    expect(screen.getByRole("radio", { name: "Session — Claude and GPT Models" })).toBeInTheDocument()
+    await user.click(screen.getByRole("radio", { name: /^Weekly$/ }))
     await user.click(screen.getByRole("button", { name: "Apply" }))
-    expect(onSetCursorTrayMetricForAllAccounts).toHaveBeenCalledWith("Credits")
+    expect(onSetTrayReadout).toHaveBeenCalledWith("antigravity", "Weekly")
     expect(onMenubarIconStyleChange).toHaveBeenCalledWith("donut")
   })
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -78,6 +78,7 @@ import {
 import { formatOsDiagnosticsLine, type OsDiagnosticsPayload } from "@/lib/os-diagnostics-format";
 import { cn } from "@/lib/utils";
 import { LayoutPreviewClassic, LayoutPreviewModern } from "@/components/ui-layout-preview";
+import { TrayReadoutDialog, type TrayReadoutDialogState } from "@/components/tray-readout-dialog";
 import { useAppPreferencesStore } from "@/stores/app-preferences-store";
 import { fireMotionShock } from "@/components/motion-field";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -86,37 +87,20 @@ import { FORK_REPO_URL } from "@/lib/fork-meta";
 import { sendNotificationAsync } from "@/lib/notification";
 import { useTranslation } from "react-i18next";
 import { useTranslatedSettingsOptions } from "@/hooks/use-translated-settings-options";
-
-const MENUBAR_STYLES_NEED_CURSOR_TRAY_PICK = new Set<MenubarIconStyle>([
-  "provider",
-  "donut",
-  "logoBar",
-  "logoGrid",
-]);
-
-const CURSOR_TRAY_METRIC_CHOICES = [
-  "Credits",
-  "Total usage",
-  "Cursor Models",
-  "Other Models",
-  "Grok Bot usage",
-  "Requests",
-] as const;
-
-function pickDefaultCursorTrayLine(plugins: SettingsPluginState[]): string {
-  const row = plugins.find((p) => p.enabled && p.baseProviderId === "cursor");
-  const first = row?.trayLines?.[0];
-  if (first && (CURSOR_TRAY_METRIC_CHOICES as readonly string[]).includes(first)) {
-    return first;
-  }
-  return "Total usage";
-}
+import { useModernLayoutStore } from "@/stores/modern-layout-store";
+import {
+  defaultTrayReadoutLine,
+  defaultTrayReadoutPluginId,
+  shouldOpenTrayReadoutDialog,
+} from "@/lib/tray-readout-pick";
 
 function trayBarPrimaryFraction(bar: TrayPrimaryBar | undefined): number {
   return bar?.items[0]?.fraction ?? 0;
 }
 
 const TRAY_PREVIEW_SIZE_PX = getTrayIconSizePx(1);
+/** Style picker uses a mid fill so pie / logo-fill / full logo don't all look identical at 90%+ remaining. */
+const TRAY_STYLE_DEMO_FRACTION = 0.62;
 
 const PREVIEW_BAR_TRACK_PX = 20;
 
@@ -354,11 +338,10 @@ function MenubarIconStylePreview({
   }
 
   if (style === "logoBar") {
-    const fraction = trayBarPrimaryFraction(traySettingsPreview.providerBars[0]);
     return (
       <ProviderLogoFillPreview
         iconUrl={traySettingsPreview.providerIconUrl}
-        fraction={fraction}
+        fraction={TRAY_STYLE_DEMO_FRACTION}
         isActive={isActive}
         sizePx={TRAY_PREVIEW_SIZE_PX}
       />
@@ -374,7 +357,7 @@ function MenubarIconStylePreview({
           <ProviderLogoFillPreview
             key={bar.id}
             iconUrl={traySettingsPreview.providerIconUrls[bar.id] ?? traySettingsPreview.providerIconUrl}
-            fraction={trayBarPrimaryFraction(bar)}
+            fraction={TRAY_STYLE_DEMO_FRACTION}
             isActive={isActive}
             sizePx={Math.max(9, Math.round(TRAY_PREVIEW_SIZE_PX * 0.48))}
           />
@@ -384,11 +367,10 @@ function MenubarIconStylePreview({
   }
 
   if (style === "donut") {
-    const fraction = trayBarPrimaryFraction(traySettingsPreview.providerBars[0]);
     return (
       <ProviderLogoPiePreview
         iconUrl={traySettingsPreview.providerIconUrl}
-        fraction={fraction}
+        fraction={TRAY_STYLE_DEMO_FRACTION}
         isActive={isActive}
         sizePx={TRAY_PREVIEW_SIZE_PX}
       />
@@ -1253,7 +1235,7 @@ interface SettingsPageProps {
   showAccountIdentity: boolean;
   onShowAccountIdentityChange: (value: boolean) => void;
   cursorRequestsLineAvailable: boolean | null;
-  onSetCursorTrayMetricForAllAccounts: (lineLabel: string) => void;
+  onSetTrayReadout: (pluginId: string, lineLabel: string) => void;
   presentation?: "classic" | "modern";
 }
 
@@ -1313,7 +1295,7 @@ export function SettingsPage({
   showAccountIdentity,
   onShowAccountIdentityChange,
   cursorRequestsLineAvailable,
-  onSetCursorTrayMetricForAllAccounts,
+  onSetTrayReadout,
   presentation = "classic",
 }: SettingsPageProps) {
   const { t } = useTranslation();
@@ -1344,10 +1326,7 @@ export function SettingsPage({
   const [logPathMessage, setLogPathMessage] = useState<string | null>(null);
   const [usageAlertTestMessage, setUsageAlertTestMessage] = useState<string | null>(null);
   const [troubleshootingOsLine, setTroubleshootingOsLine] = useState<string | null>(null);
-  const [cursorTrayIconDialog, setCursorTrayIconDialog] = useState<{
-    nextStyle: MenubarIconStyle;
-    selectedLine: string;
-  } | null>(null);
+  const [trayReadoutDialog, setTrayReadoutDialog] = useState<TrayReadoutDialogState | null>(null);
   const [usageHistorySectionKey, setUsageHistorySectionKey] = useState(0);
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -1400,15 +1379,21 @@ export function SettingsPage({
 
   const handleMenubarIconStyleOptionClick = (style: MenubarIconStyle) => {
     if (style === menubarIconStyle) return;
-    const needsPick =
-      MENUBAR_STYLES_NEED_CURSOR_TRAY_PICK.has(style) &&
-      plugins.some((p) => p.enabled && p.baseProviderId === "cursor");
-    if (needsPick) {
-      setCursorTrayIconDialog({
-        nextStyle: style,
-        selectedLine: pickDefaultCursorTrayLine(plugins),
-      });
-      return;
+    if (shouldOpenTrayReadoutDialog(style, plugins)) {
+      const preferredId =
+        useModernLayoutStore.getState().trayFocusProviderId ??
+        traySettingsPreview.providerBars[0]?.id ??
+        null;
+      const pluginId = defaultTrayReadoutPluginId(plugins, preferredId);
+      const plugin = plugins.find((p) => p.id === pluginId);
+      if (pluginId && plugin) {
+        setTrayReadoutDialog({
+          nextStyle: style,
+          pluginId,
+          lineLabel: defaultTrayReadoutLine(plugin),
+        });
+        return;
+      }
     }
     onMenubarIconStyleChange(style);
   };
@@ -2253,62 +2238,16 @@ export function SettingsPage({
         </div>
       </section>
       ) : null}
-      {cursorTrayIconDialog ? (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          role="presentation"
-          onClick={() => setCursorTrayIconDialog(null)}
-        >
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="cursor-tray-dialog-title"
-            className="max-w-md w-full rounded-lg border border-border bg-card p-4 shadow-lg"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <h3 id="cursor-tray-dialog-title" className="text-base font-semibold text-foreground">
-              Cursor tray readout
-            </h3>
-            <p className="text-sm text-muted-foreground mt-1 mb-3">
-              Pick the Cursor metric for this icon style. Credits use dollar amounts in the tray; other lines use your
-              usage mode (Used vs Left) like the rest of the app. You can still adjust line checkboxes per account under
-              Plugins.
-            </p>
-            <div className="flex flex-col gap-2" role="radiogroup" aria-label="Cursor tray metric">
-              {CURSOR_TRAY_METRIC_CHOICES.map((line) => (
-                <label key={line} className="flex items-center gap-2 text-sm cursor-pointer select-none">
-                  <input
-                    type="radio"
-                    name="cursor-tray-metric"
-                    className="accent-primary"
-                    checked={cursorTrayIconDialog.selectedLine === line}
-                    onChange={() =>
-                      setCursorTrayIconDialog((d) => (d ? { ...d, selectedLine: line } : d))
-                    }
-                  />
-                  <span>{line}</span>
-                </label>
-              ))}
-            </div>
-            <div className="flex justify-end gap-2 mt-4">
-              <Button type="button" variant="outline" size="sm" onClick={() => setCursorTrayIconDialog(null)}>
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => {
-                  onSetCursorTrayMetricForAllAccounts(cursorTrayIconDialog.selectedLine);
-                  onMenubarIconStyleChange(cursorTrayIconDialog.nextStyle);
-                  setCursorTrayIconDialog(null);
-                }}
-              >
-                Apply
-              </Button>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      <TrayReadoutDialog
+        dialog={trayReadoutDialog}
+        plugins={plugins}
+        onClose={() => setTrayReadoutDialog(null)}
+        onApply={(pluginId, lineLabel, nextStyle) => {
+          onSetTrayReadout(pluginId, lineLabel);
+          onMenubarIconStyleChange(nextStyle);
+          setTrayReadoutDialog(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/stores/modern-layout-store.test.ts
+++ b/src/stores/modern-layout-store.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/settings", () => ({
+  loadModernLayout: vi.fn(),
+  saveModernLayout: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { metricId } from "@/lib/metric-id"
+import { EMPTY_MODERN_LAYOUT } from "@/lib/modern-layout"
+import type { MetricDescriptor } from "@/lib/metric-registry"
+import { useModernLayoutStore } from "@/stores/modern-layout-store"
+
+const claudeSession = metricId("claude", "Session")
+const claudeWeekly = metricId("claude", "Weekly")
+const antigravityWeekly = metricId("antigravity", "Weekly")
+const cursorCredits = metricId("cursor", "Credits")
+
+function desc(pluginId: string, lineLabel: string): MetricDescriptor {
+  return {
+    id: metricId(pluginId, lineLabel),
+    pluginId,
+    lineLabel,
+    manifest: { type: "progress", label: lineLabel, scope: "overview" },
+    displayName: pluginId,
+    bounded: true,
+  }
+}
+
+const descriptors = [
+  desc("claude", "Session"),
+  desc("claude", "Weekly"),
+  desc("antigravity", "Weekly"),
+  desc("cursor", "Credits"),
+]
+
+describe("modern-layout-store tray readout", () => {
+  beforeEach(() => {
+    useModernLayoutStore.setState({
+      ...EMPTY_MODERN_LAYOUT,
+      hydrated: true,
+      pinLimitNotice: null,
+      initialized: true,
+      pinnedMetricIds: [claudeSession, cursorCredits],
+      trayFocusProviderId: "claude",
+    })
+  })
+
+  it("applyTrayReadout focuses the plugin and pins its meter first", () => {
+    useModernLayoutStore.getState().applyTrayReadout("antigravity", "Weekly")
+    const state = useModernLayoutStore.getState()
+    expect(state.trayFocusProviderId).toBe("antigravity")
+    expect(state.pinnedMetricIds[0]).toBe(antigravityWeekly)
+    expect(state.pinnedMetricIds).toContain(claudeSession)
+    expect(state.pinnedMetricIds).toContain(cursorCredits)
+  })
+
+  it("syncPinsFromTrayLines does not overwrite pins or focus after init", () => {
+    useModernLayoutStore.getState().applyTrayReadout("antigravity", "Weekly")
+    useModernLayoutStore.getState().syncPinsFromTrayLines(
+      {
+        claude: ["Session", "Weekly"],
+        antigravity: ["Weekly"],
+      },
+      descriptors,
+    )
+    const state = useModernLayoutStore.getState()
+    expect(state.trayFocusProviderId).toBe("antigravity")
+    expect(state.pinnedMetricIds[0]).toBe(antigravityWeekly)
+    expect(state.pinnedMetricIds).toEqual([
+      antigravityWeekly,
+      claudeSession,
+      cursorCredits,
+    ])
+    expect(state.pinnedMetricIds).not.toContain(claudeWeekly)
+  })
+})

--- a/src/stores/modern-layout-store.test.ts
+++ b/src/stores/modern-layout-store.test.ts
@@ -54,6 +54,23 @@ describe("modern-layout-store tray readout", () => {
     expect(state.pinnedMetricIds).toContain(cursorCredits)
   })
 
+  it("applyTrayReadout leaves an already-pinned only meter in place", () => {
+    useModernLayoutStore.getState().applyTrayReadout("cursor", "Credits")
+    const state = useModernLayoutStore.getState()
+    expect(state.trayFocusProviderId).toBe("cursor")
+    expect(state.pinnedMetricIds).toEqual([claudeSession, cursorCredits])
+  })
+
+  it("applyTrayReadout reorders sibling pins within the provider group", () => {
+    useModernLayoutStore.setState({
+      pinnedMetricIds: [claudeSession, claudeWeekly, cursorCredits],
+    })
+    useModernLayoutStore.getState().applyTrayReadout("claude", "Weekly")
+    const state = useModernLayoutStore.getState()
+    expect(state.trayFocusProviderId).toBe("claude")
+    expect(state.pinnedMetricIds).toEqual([claudeWeekly, claudeSession, cursorCredits])
+  })
+
   it("syncPinsFromTrayLines does not overwrite pins or focus after init", () => {
     useModernLayoutStore.getState().applyTrayReadout("antigravity", "Weekly")
     useModernLayoutStore.getState().syncPinsFromTrayLines(

--- a/src/stores/modern-layout-store.ts
+++ b/src/stores/modern-layout-store.ts
@@ -141,7 +141,7 @@ export const useModernLayoutStore = create<ModernLayoutStore>((set, get) => ({
       pinned.splice(existingIdx, 1)
       const insertAt = pinned.findIndex((p) => parseMetricId(p)?.pluginId === pluginId)
       if (insertAt >= 0) pinned.splice(insertAt, 0, id)
-      else pinned.unshift(id)
+      else pinned.splice(existingIdx, 0, id)
     } else if (providerIdxs.length >= MAX_PINS_PER_PROVIDER) {
       pinned[providerIdxs[0]] = id
     } else {

--- a/src/stores/modern-layout-store.ts
+++ b/src/stores/modern-layout-store.ts
@@ -1,8 +1,9 @@
 import { create } from "zustand"
-import { parseMetricId } from "@/lib/metric-id"
+import { metricId, parseMetricId } from "@/lib/metric-id"
 import {
   DEFAULT_PINNED_METRIC_IDS,
   EMPTY_MODERN_LAYOUT,
+  MAX_PINS_PER_PROVIDER,
   canPinMetric,
   pinnedIdsFromTrayLines,
   placedIdsFromPluginSettings,
@@ -28,6 +29,7 @@ type ModernLayoutStore = ModernLayoutState & {
   setProviderMetricsEnabled: (pluginId: string, metricIds: string[], enabled: boolean) => void
   togglePin: (metricIdValue: string) => boolean
   setTrayFocusProvider: (pluginId: string | null) => void
+  applyTrayReadout: (pluginId: string, lineLabel: string) => void
   setPinnedOrder: (order: string[]) => void
   syncDescriptors: (descriptors: MetricDescriptor[]) => void
   syncPinsFromTrayLines: (trayLines: Record<string, string[]> | undefined, descriptors: MetricDescriptor[]) => void
@@ -126,6 +128,32 @@ export const useModernLayoutStore = create<ModernLayoutStore>((set, get) => ({
     void get().persist()
   },
 
+  applyTrayReadout: (pluginId, lineLabel) => {
+    const id = metricId(pluginId, lineLabel)
+    const pinned = [...get().pinnedMetricIds]
+    const existingIdx = pinned.indexOf(id)
+    const providerIdxs: number[] = []
+    for (let i = 0; i < pinned.length; i++) {
+      if (parseMetricId(pinned[i])?.pluginId === pluginId) providerIdxs.push(i)
+    }
+
+    if (existingIdx >= 0) {
+      pinned.splice(existingIdx, 1)
+      const insertAt = pinned.findIndex((p) => parseMetricId(p)?.pluginId === pluginId)
+      if (insertAt >= 0) pinned.splice(insertAt, 0, id)
+      else pinned.unshift(id)
+    } else if (providerIdxs.length >= MAX_PINS_PER_PROVIDER) {
+      pinned[providerIdxs[0]] = id
+    } else {
+      const insertAt = pinned.findIndex((p) => parseMetricId(p)?.pluginId === pluginId)
+      if (insertAt >= 0) pinned.splice(insertAt, 0, id)
+      else pinned.unshift(id)
+    }
+
+    set({ pinnedMetricIds: pinned, trayFocusProviderId: pluginId, pinLimitNotice: null })
+    void get().persist()
+  },
+
   setPinnedOrder: (order) => {
     set({ pinnedMetricIds: order, pinLimitNotice: null })
     void get().persist()
@@ -156,13 +184,13 @@ export const useModernLayoutStore = create<ModernLayoutStore>((set, get) => ({
     const current = get()
     if (!current.initialized || !trayLines || Object.keys(trayLines).length === 0) return
 
+    // Pins and tray focus are user-chosen in Modern (and by applyTrayReadout).
+    // Rebuilding from trayLines would drop customized pins and overwrite the
+    // provider the tray-readout dialog just applied (fromTray[0] is map order).
+    if (current.pinnedMetricIds.length > 0) return
+
     const fromTray = filterKnown(pinnedIdsFromTrayLines(trayLines), descriptors)
     if (fromTray.length === 0) return
-
-    const same =
-      fromTray.length === current.pinnedMetricIds.length &&
-      fromTray.every((id, i) => current.pinnedMetricIds[i] === id)
-    if (same) return
 
     set({
       pinnedMetricIds: fromTray,


### PR DESCRIPTION
## Summary
- Restore 1.4.3 tray fixes: Classic follows the open sidebar provider (Modern pin focus no longer freezes Classic), generalized **Tray readout** dialog (portal to `document.body`), mid-fill style previews so pie/fill/logo are distinguishable.
- Full-color logos (SVG without `currentColor`, rasters) render as images in the tray and UI.
- **Not in this PR:** Gemini Apps and Grok.com stay lab-only.

## Test plan
- [ ] Settings: click Logo+%, Logo fill, Pie, All logos → **Tray readout** dialog (Cancel/Apply); Battery bars apply immediately
- [ ] Classic: switching sidebar providers changes the tray logo
- [ ] Modern: clicking a provider header can set tray focus without freezing Classic after switching layouts
- [ ] `bun run test src/pages/settings.test.tsx src/lib/tray-provider-id.test.ts src/lib/tray-readout-pick.test.ts src/hooks/app/use-settings-plugin-actions.test.ts`


Made with [Cursor](https://cursor.com)